### PR TITLE
Improve component name placeholder

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -223,7 +223,7 @@ log() {
     if test -z "$COMPONENT"; then
         # only message was passed
         if test "$#" -eq 1; then
-            COMPONENT='[unknown]'
+            COMPONENT='[unknown-component]'
         else
             COMPONENT=$1 ; shift
         fi

--- a/preup/script_api.py
+++ b/preup/script_api.py
@@ -273,7 +273,7 @@ USER_CONFIG_FILE = 0
 #
 PREUPG_API_VERSION = 1
 
-component = "[unknown]"
+component = "[unknown-component]"
 
 
 ################

--- a/preup/script_api.py
+++ b/preup/script_api.py
@@ -273,7 +273,7 @@ USER_CONFIG_FILE = 0
 #
 PREUPG_API_VERSION = 1
 
-component = "unknown"
+component = "[unknown]"
 
 
 ################


### PR DESCRIPTION
Bash API uses '[unknown]' so Python API should do the same.