### PR TITLE
Improve logging format

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -233,7 +233,7 @@ log() {
         fi
     fi
 
-    echo "$SEVERITY $COMPONENT: $1" >&2
+    echo "preupg.log.$SEVERITY: $COMPONENT: $1" >&2
 }
 
 log_debug() {

--- a/common.sh
+++ b/common.sh
@@ -297,7 +297,7 @@ log_risk() {
     #
     # log risk level to stderr
     #
-    echo "INPLACERISK: $1: $2" >&2
+    echo "preupg.risk.$1: $2" >&2
 }
 
 log_none_risk() {

--- a/preup/script_api.py
+++ b/preup/script_api.py
@@ -284,7 +284,7 @@ def log_risk(severity, message):
     """
     log risk level to stderr
     """
-    print("INPLACERISK: %s: %s\n" % (severity, message.encode(settings.defenc)), end="", file=sys.stderr)
+    print("preupg.risk.%s: %s\n" % (severity, message.encode(settings.defenc)), end="", file=sys.stderr)
 
 
 def log_extreme_risk(message):

--- a/preup/script_api.py
+++ b/preup/script_api.py
@@ -342,7 +342,7 @@ def log(severity, message, component_arg=None):
     """
     global component
     comp_show = component_arg or component
-    print("%s %s: %s\n" % (severity, comp_show, message.encode(settings.defenc)), end="", file=sys.stderr)
+    print("preupg.log.%s: %s: %s\n" % (severity, comp_show, message.encode(settings.defenc)), end="", file=sys.stderr)
 
 
 def log_error(message, component_arg=None):

--- a/preup/xccdf.py
+++ b/preup/xccdf.py
@@ -54,7 +54,7 @@ class XccdfHelper(object):
         Function returns implace risks
         """
         inplace_risk = []
-        risk_regex = "INPLACERISK: (?P<level>\w+): (?P<message>.+)"
+        risk_regex = "preupg\.risk\.(?P<level>\w+): (?P<message>.+)"
         for check in tree.findall(".//" + XMLNS + "check-import"):
             if not check.text:
                 continue
@@ -70,7 +70,7 @@ class XccdfHelper(object):
     def check_inplace_risk(xccdf_file, verbose):
         """
         The function read the content of the file
-        and finds out all INPLACERISK rows in TestResult tree.
+        and finds out all "preupg.risk" rows in TestResult tree.
         return value is get from function get_and_print_inplace_risk
         """
         message = "'preupg' command was not run yet. Run 'preupg' before getting list of risks."

--- a/preup/xml_manager.py
+++ b/preup/xml_manager.py
@@ -102,7 +102,7 @@ def tag_formating(text, extension):
             for match in string_match:
                 # update = update_dict[string_match.group("tag")](match, extension)
                 inplace = False
-                if 'INPLACERISK:' in line:
+                if 'preupg.risk.' in line:
                     inplace = True
                 update = update_dict[match[0]](match[1], extension, inplace)
                 if update != "":
@@ -268,9 +268,9 @@ class XmlManager(object):
                 logger_report.debug("Solution text '%s' name '%s'", solution_text, file_name)
                 text = FileHelper.get_file_content(os.path.join(dir_name, file_name), "rb", method=True)
             for cnt, line in enumerate(lines):
-                # If in INPLACERISK: is a [link] then update them
+                # If in preupg.risk is a [link] then update them
                 # to /root/pre{migrate,upgrade}/...
-                if 'INPLACERISK:' in line.strip():
+                if 'preupg.risk.' in line.strip():
                     logger_report.debug(line.strip())
                     lines[cnt] = tag_formating([line], extension)[0]
                     continue

--- a/preup_ui/report/processing.py
+++ b/preup_ui/report/processing.py
@@ -193,7 +193,7 @@ class ReportParser(object):
         lines = text.split('\n')
 
         log_regex = "preupg\.log\.(?P<level>(ERROR|WARNING|INFO|DEBUG)): (?P<component>\S+): (?P<date_str>\S+) (?P<time>\S+) (?P<message>.+)"
-        risk_regex = "INPLACERISK: (?P<level>\w+): (?P<message>.+)"
+        risk_regex = "preupg\.risk\.(?P<level>\w+): (?P<message>.+)"
         date_format = '%Y-%m-%d %H:%M'
         logs = []
         risks = []

--- a/preup_ui/report/processing.py
+++ b/preup_ui/report/processing.py
@@ -192,7 +192,7 @@ class ReportParser(object):
         text = text.strip()
         lines = text.split('\n')
 
-        log_regex = "(?P<level>(ERROR|WARNING|INFO|DEBUG)) (?P<component>\S+) (?P<date_str>\S+) (?P<time>\S+) (?P<message>.+)"
+        log_regex = "preupg\.log\.(?P<level>(ERROR|WARNING|INFO|DEBUG)): (?P<component>\S+): (?P<date_str>\S+) (?P<time>\S+) (?P<message>.+)"
         risk_regex = "INPLACERISK: (?P<level>\w+): (?P<message>.+)"
         date_format = '%Y-%m-%d %H:%M'
         logs = []

--- a/tests/FOOBAR6_7/dummy/needs_action/dummy_failed.sh
+++ b/tests/FOOBAR6_7/dummy/needs_action/dummy_failed.sh
@@ -2,7 +2,7 @@
 
 echo "Dummy needs_action test"
 
-echo "INPLACERISK: HIGH: This is High Risk"
+echo "preupg.risk.HIGH: This is High Risk"
 
 . /usr/share/preupgrade/common.sh
 #END GENERATED SECTION

--- a/tests/FOOBAR6_7/dummy/needs_action/solution.txt
+++ b/tests/FOOBAR6_7/dummy/needs_action/solution.txt
@@ -1,3 +1,3 @@
 This is solution text for Dummy Failed
 
-INPLACERISK: HIGH: High inplace risk
+preupg.risk.HIGH: High inplace risk

--- a/tests/FOOBAR6_7/dummy/needs_inspection/dummy_failed.sh
+++ b/tests/FOOBAR6_7/dummy/needs_inspection/dummy_failed.sh
@@ -2,7 +2,7 @@
 
 echo "Dummy needs_inspection test"
 
-echo "INPLACERISK: NONE: This is None Risk"
+echo "preupg.risk.NONE: This is None Risk"
 
 
 

--- a/tests/FOOBAR6_7/dummy/needs_inspection/solution.txt
+++ b/tests/FOOBAR6_7/dummy/needs_inspection/solution.txt
@@ -1,3 +1,3 @@
 This is solution text for Dummy Failed
 
-INPLACERISK: NONE: None inplace risk
+preupg.risk.NONE: None inplace risk

--- a/tests/test_inplace_risks.py
+++ b/tests/test_inplace_risks.py
@@ -60,7 +60,7 @@ class TestRiskCheck(base.TestCase):
 
     def test_check_inplace_risk_high(self):
 
-        temp_file = self._copy_xccdf_file(b'INPLACERISK: HIGH: Test High Inplace risk')
+        temp_file = self._copy_xccdf_file(b'preupg.risk.HIGH: Test High Inplace risk')
         self._generate_result(temp_file)
         return_value = XccdfHelper.check_inplace_risk(os.path.join(os.path.dirname(temp_file), 'result.xml'), 0)
         shutil.rmtree(os.path.dirname(temp_file))
@@ -68,7 +68,7 @@ class TestRiskCheck(base.TestCase):
 
     def test_check_inplace_risk_medium(self):
 
-        temp_file = self._copy_xccdf_file(b'INPLACERISK: MEDIUM: Test Medium Inplace risk')
+        temp_file = self._copy_xccdf_file(b'preupg.risk.MEDIUM: Test Medium Inplace risk')
         self._generate_result(temp_file)
         return_value = XccdfHelper.check_inplace_risk(os.path.join(os.path.dirname(temp_file), 'result.xml'), 0)
         shutil.rmtree(os.path.dirname(temp_file))
@@ -76,7 +76,7 @@ class TestRiskCheck(base.TestCase):
 
     def test_check_inplace_risk_slight(self):
 
-        temp_file = self._copy_xccdf_file(b'INPLACERISK: SLIGHT: Test Slight Inplace risk')
+        temp_file = self._copy_xccdf_file(b'preupg.risk.SLIGHT: Test Slight Inplace risk')
         self._generate_result(temp_file)
         return_value = XccdfHelper.check_inplace_risk(os.path.join(os.path.dirname(temp_file), 'result.xml'), 0)
         shutil.rmtree(os.path.dirname(temp_file))
@@ -84,7 +84,7 @@ class TestRiskCheck(base.TestCase):
 
     def test_check_inplace_risk_none(self):
 
-        temp_file = self._copy_xccdf_file(b'INPLACERISK: NONE: Test None Inplace risk')
+        temp_file = self._copy_xccdf_file(b'preupg.risk.NONE: Test None Inplace risk')
         self._generate_result(temp_file)
         return_value = XccdfHelper.check_inplace_risk(os.path.join(os.path.dirname(temp_file), 'result.xml'), 0)
         shutil.rmtree(os.path.dirname(temp_file))
@@ -92,7 +92,7 @@ class TestRiskCheck(base.TestCase):
 
     def test_check_inplace_risk_extreme(self):
 
-        temp_file = self._copy_xccdf_file(b'INPLACERISK: EXTREME: Test Extreme Inplace risk')
+        temp_file = self._copy_xccdf_file(b'preupg.risk.EXTREME: Test Extreme Inplace risk')
         self._generate_result(temp_file)
         return_value = XccdfHelper.check_inplace_risk(os.path.join(os.path.dirname(temp_file), 'result.xml'), 0)
         shutil.rmtree(os.path.dirname(temp_file))
@@ -100,7 +100,7 @@ class TestRiskCheck(base.TestCase):
 
     def test_check_inplace_risk_unknown(self):
 
-        temp_file = self._copy_xccdf_file(b'INPLACERISK: UNKNOWN: Test Extreme Inplace risk')
+        temp_file = self._copy_xccdf_file(b'preupg.risk.UNKNOWN: Test Extreme Inplace risk')
         self._generate_result(temp_file)
         return_value = XccdfHelper.check_inplace_risk(os.path.join(os.path.dirname(temp_file), 'result.xml'), 0)
         shutil.rmtree(os.path.dirname(temp_file))


### PR DESCRIPTION
Note: this is addressed by [bug 1361378][1] in downstream.  Following text is taken from there.

  [1]: https://bugzilla.redhat.com/show_bug.cgi?id=1361378

Description of problem
======================

Currently there are two issues with logging from modules:

 *  Risks use prefix "INPLACERISK:" that is not suitable for migration
    scenarios.

 *  Other log messages use format that is hard to filter out.

Together with bug 1309491 (openscap merges stderr to stdout), this makes
it hard to catch situations when scripts leak some info outside intended.

For example, "leaking" grep as in bug 1356811, sntax errors or errors
thrown by external utilities called by modules are all problems
that could be easily checked by tests *if* the formatting was more
filtering-friendly.


Proposal
========

For logging risks, use format:

    preupg.risk.MEDIUM: some risky risk

For other properly logged messages, use:

    preupg.log.INFO: some_component: I just want to let you know

This way, all properly logged messages and risks can be easily separated
from leaks or errors thrown for various reasons.