### PR TITLE
Remove forgotten echo/log

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -743,8 +743,6 @@ deploy_hook() {
     [ -z $MODULE_NAME ] && return 0
     case $deploy_name in
         "postupgrade")
-            pwd=`pwd`
-            echo "$pwd"
             if [ ! -f "$script_name" ] ; then
                 log_error "Script_name $script_name does not exist."
                 return 1

--- a/preup/script_api.py
+++ b/preup/script_api.py
@@ -770,8 +770,6 @@ def deploy_hook(deploy_name, script_name):
     if MODULE_NAME == "":
         return 0
     if deploy_name == "postupgrade":
-        pwd = os.getcwd()
-        _log(pwd)
         if not os.path.exists(script_name):
             log_error ("Script_name %s does not exist.", script_name)
             return 1


### PR DESCRIPTION
In Python API, this ilegally calls internal log function.

In Bash API, this is a stray output.

In both cases `$pwd` variable exists only for the log, so removing that
as well.