### PR TITLE
Fix argument parsing

### DIFF
--- a/preup/script_api.py
+++ b/preup/script_api.py
@@ -783,13 +783,13 @@ def deploy_hook(*args):
 
     if MODULE_PATH == "":
         return 0
-    if args[0] == "":
+    if len(args) < 1:
         log_error("Hook name is not specified. (Possible values are postupgrade, preupgrade.)")
         exit_error()
-    deploy_name = args[0]
-    if args[1] == "":
+    elif len(args) < 2:
         log_error("Script name is not specified. It is mandatory.")
         exit_error()
+    deploy_name = args[0]
     script_name = args[1]
     if deploy_name == "postupgrade" or deploy_name == "preupgrade":
         if not os.path.exists(script_name):


### PR DESCRIPTION
When there's less than 1 arg, `arg[0]` is not a valid expression and
will raise IndexError.  That's what happended in cases when either script
name or both script name and hook type were not specified.

This commit changes the error handling so that it will actually work.