### PR TITLE
Fix error message formatting

### DIFF
--- a/preup/script_api.py
+++ b/preup/script_api.py
@@ -828,7 +828,7 @@ def deploy_hook(*args):
             exit_error()
 
     else:
-        log_error("Unknown hook option '%s'", deploy_name)
+        log_error("Unknown hook option '%s'" % deploy_name)
         exit_error()
 
 load_pa_configuration()


### PR DESCRIPTION
This syntax is incorrect; it means log error with text *literally*
"Unknown hook option '%s'" as if related to component deploy_name.