### PR TITLE
Implementation postmigrate.d directory

### DIFF
--- a/kickstart/finish.sh
+++ b/kickstart/finish.sh
@@ -30,7 +30,7 @@ do
     fi
 done
 cd ${PWD}
-POST_INSTALL_SCRIPTS="postinstall.d"
+POST_INSTALL_SCRIPTS="postmigrate.d"
 cd $POST_INSTALL_SCRIPTS
 for file in $(find . -type f -executable)
 do

--- a/kickstart/finish.sh
+++ b/kickstart/finish.sh
@@ -30,8 +30,8 @@ do
     fi
 done
 cd ${PWD}
-KS_SCRIPTS="kickstart/scripts"
-cd $KS_SCRIPTS
+POST_INSTALL_SCRIPTS="postinstall.d"
+cd $POST_INSTALL_SCRIPTS
 for file in $(find . -type f -executable)
 do
     echo "Running script ${file} ..." >> ${PREUPGRADE_LOG}

--- a/preup/kickstart/application.py
+++ b/preup/kickstart/application.py
@@ -212,7 +212,7 @@ class KickstartGenerator(object):
                 kickstart_data[index] = "#" + row
         FileHelper.write_to_file(self.kick_start_name, 'wb', kickstart_data)
 
-    def check_postimigrate_dir(self):
+    def check_postmigrate_dir(self):
         if not FileHelper.get_list_executable_files_in_dir(os.path.join(settings.result_dir,
                                                                         settings.postmigrate_dir)):
             if not self.conf.assumeyes:
@@ -232,7 +232,7 @@ class KickstartGenerator(object):
         if not self.collect_data():
             log_message("Important data are missing for the Kickstart generation.", level=logging.ERROR)
             return None
-        if not self.check_postimigrate_dir():
+        if not self.check_postmigrate_dir():
             return None
         self.ks.handler.packages.excludedList = []
         self.plugin_classes = self.load_plugins(os.path.dirname(__file__))

--- a/preup/kickstart/application.py
+++ b/preup/kickstart/application.py
@@ -196,13 +196,14 @@ class KickstartGenerator(object):
         list_issues = [' --', 'group', 'user ', 'repo', 'url', 'rootpw']
         kickstart_data = []
         try:
-            kickstart_data = FileHelper.get_file_content(os.path.join(settings.KS_DIR, self.kick_start_name),
+            kickstart_data = FileHelper.get_file_content(os.path.join(settings.KS_DIR,
+                                                                      self.kick_start_name),
                                                          'rb',
                                                          method=True,
                                                          decode_flag=False)
         except IOError:
-            log_message("The %s file is missing. The partitioning layout might not be complete." % self.kick_start_name,
-                        level=logging.WARNING)
+            log_message("The %s file is missing. The partitioning layout "
+                        "might not be complete." % self.kick_start_name, level=logging.WARNING)
             return None
         for index, row in enumerate(kickstart_data):
             tag = [com for com in list_issues if row.startswith(com)]
@@ -210,22 +211,28 @@ class KickstartGenerator(object):
                 kickstart_data[index] = "#" + row
         FileHelper.write_to_file(self.kick_start_name, 'wb', kickstart_data)
 
+    def check_postimigrate_dir(self):
+        if not FileHelper.get_list_executable_files_in_dir(os.path.join(settings.result_dir,
+                                                                        settings.kickstart_dir)):
+            if not self.conf.assumeyes:
+                accept = ['y', 'yes']
+                log_message("The '%s' folder is empty - scripts to be executed "
+                            "after the migration should be placed "
+                            "here." % os.path.join(settings.result_dir,
+                                                   settings.postmigrate_dir))
+                message = "Do you want to continue with kickstart " \
+                          "generation without any postmigration scripts?"
+                choice = MessageHelper.get_message(message=message, prompt="(Y/n)")
+                if choice.lower() not in accept:
+                    return None
+        return True
+
     def generate(self):
         if not self.collect_data():
             log_message("Important data are missing for the Kickstart generation.", level=logging.ERROR)
             return None
-        if not self.conf.force:
-            if not FileHelper.get_list_executable_files_in_dir(os.path.join(settings.result_dir,
-                                                                            settings.kickstart_dir)):
-                accept = ['y', 'yes']
-                log_message("The '%s' folder is empty - scripts to be executed "
-                            "after the migration should be placed here." % os.path.join(settings.result_dir,
-                                                                                        settings.postmigrate_dir))
-                message = "Do you want to continue with kickstart generation without any postmigration scripts?"
-                choice = MessageHelper.get_message(message=message,
-                                                   prompt="(Y/n)")
-                if choice.lower() not in accept:
-                    return None
+        if not self.check_postimigrate_dir():
+            return None
         self.ks.handler.packages.excludedList = []
         self.plugin_classes = self.load_plugins(os.path.dirname(__file__))
         for module in six.iterkeys(self.plugin_classes):

--- a/preup/kickstart/application.py
+++ b/preup/kickstart/application.py
@@ -213,7 +213,7 @@ class KickstartGenerator(object):
 
     def check_postimigrate_dir(self):
         if not FileHelper.get_list_executable_files_in_dir(os.path.join(settings.result_dir,
-                                                                        settings.kickstart_dir)):
+                                                                        settings.postmigrate_dir)):
             if not self.conf.assumeyes:
                 accept = ['y', 'yes']
                 log_message("The '%s' folder is empty - scripts to be executed "

--- a/preup/kickstart/application.py
+++ b/preup/kickstart/application.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import print_function, unicode_literals
 
 """
 Class creates a kickstart for migration scenario

--- a/preup/kickstart/cli.py
+++ b/preup/kickstart/cli.py
@@ -12,11 +12,19 @@ class CLIKickstart(object):
 
         #self.parser.usage = "%%prog [-v] <content_file>"
 
-        #self.add_args()
+        self.add_args()
         if args:
             self.opts, self.args = self.parser.parse_args(args=args)
         else:
             self.opts, self.args = self.parser.parse_args()
+
+    def add_args(self):
+        self.parser.add_option(
+            "--force",
+            action="store_true",
+            default=False,
+            help="Suppress user interaction"
+        )
 
 
 if __name__ == '__main__':

--- a/preup/kickstart/cli.py
+++ b/preup/kickstart/cli.py
@@ -20,7 +20,8 @@ class CLIKickstart(object):
 
     def add_args(self):
         self.parser.add_option(
-            "--force",
+            "-y",
+            "--assumeyes",
             action="store_true",
             default=False,
             help="Suppress user interaction"

--- a/preup/settings.py
+++ b/preup/settings.py
@@ -95,15 +95,22 @@ file_list_rules = "list_rules"
 # path to file with definitions of common scripts
 post_script = os.path.join(common_dir, "post_scripts.txt")
 
+# kickstart directory name
+kickstart_dir = "kickstart"
+
+# kickstart postinstall directory name
+postinstall_dir = "postinstall.d"
+
 # kickstart and postupgrade.d directories
 preupgrade_dirs = [dirty_conf_dir, clean_conf_dir,
-                   'hooks', 'kickstart', postupgrade_dir, 'common',
-                   'preupgrade-scripts', 'noauto_postupgrade.d']
+                   'hooks', kickstart_dir, postupgrade_dir, 'common',
+                   'preupgrade-scripts', 'noauto_postupgrade.d',
+                   postinstall_dir]
 
 
 PREUPG_README = 'README'
 readme_files = {'README': PREUPG_README,
-                'README.kickstart': os.path.join('kickstart', 'README'),
+                'README.kickstart': os.path.join(kickstart_dir, 'README'),
                 }
 
 # Used for autogeneration check script issues
@@ -173,7 +180,7 @@ ui_command = "preupg -u http://example.com:8099/submit/ -r {0}"
 openssl_command = "openssl x509 -text -in {0} | grep -A1 1.3.6.1.4.1.2312.9.1"
 
 UPGRADE_PATH = ""
-KS_DIR = os.path.join(result_dir, 'kickstart')
+KS_DIR = os.path.join(result_dir, kickstart_dir)
 KS_TEMPLATE = 'default.ks'
 KS_TEMPLATE_POSTSCRIPT = 'finish.sh'
 KS_TEMPLATES = [KS_TEMPLATE, KS_TEMPLATE_POSTSCRIPT]

--- a/preup/settings.py
+++ b/preup/settings.py
@@ -99,13 +99,13 @@ post_script = os.path.join(common_dir, "post_scripts.txt")
 kickstart_dir = "kickstart"
 
 # kickstart postinstall directory name
-postinstall_dir = "postinstall.d"
+postmigrate_dir = "postmigrate.d"
 
 # kickstart and postupgrade.d directories
 preupgrade_dirs = [dirty_conf_dir, clean_conf_dir,
                    'hooks', kickstart_dir, postupgrade_dir, 'common',
                    'preupgrade-scripts', 'noauto_postupgrade.d',
-                   postinstall_dir]
+                   postmigrate_dir]
 
 
 PREUPG_README = 'README'

--- a/preup/utils.py
+++ b/preup/utils.py
@@ -292,7 +292,7 @@ class FileHelper(object):
         for (root_path, dirs, files) in os.walk(dir_name):
             for f in files:
                 file_name = os.path.join(root_path, f)
-                if os.path.exists(file_name) and FileHelper.check_file(file_name, u"x") is True:
+                if os.path.exists(file_name) and FileHelper.check_file(file_name, "x") is True:
                     found_scripts.append(file_name)
         return found_scripts
 

--- a/preup/utils.py
+++ b/preup/utils.py
@@ -280,6 +280,22 @@ class FileHelper(object):
                       }
         return file_types[mime_type]
 
+    @staticmethod
+    def get_list_executable_files_in_dir(dir_name):
+        """
+        The function returns list of executable files in directory.
+
+        :param dir_name: Dir name where executable files are searched
+        :return: List of files or empty list
+        """
+        found_scripts = []
+        for (root_path, dirs, files) in os.walk(dir_name):
+            for f in files:
+                file_name = os.path.join(root_path, f)
+                if os.path.exists(file_name) and FileHelper.check_file(file_name, u"x") is True:
+                    found_scripts.append(file_name)
+        return found_scripts
+
 
 class DirHelper(object):
 

--- a/tests/test_kickstart.py
+++ b/tests/test_kickstart.py
@@ -6,6 +6,8 @@ import tempfile
 import shutil
 
 from preup.kickstart.application import KickstartGenerator
+from preup.kickstart.cli import CLIKickstart
+from preup.kickstart.conf import ConfKickstart, DummyConfKickstart
 from preup import settings
 
 try:
@@ -69,7 +71,12 @@ class TestKickstartPartitioning(base.TestCase):
                         os.path.join(self.WORKING_DIR, kickstart_file))
         shutil.copyfile(os.path.join(os.getcwd(), 'kickstart', default_ks),
                         os.path.join(self.WORKING_DIR, default_ks))
-        self.kg = KickstartGenerator(None, self.WORKING_DIR, os.path.join(kickstart_file))
+        conf = {"force": True}
+        dc = DummyConfKickstart(**conf)
+        cli_kickstart = CLIKickstart(["--force"])
+        conf = ConfKickstart(cli_kickstart.opts, dc, cli_kickstart)
+        app = KickstartGenerator(conf, settings.KS_DIR, settings.PREUPGRADE_KS)
+        self.kg = KickstartGenerator(conf, self.WORKING_DIR, os.path.join(kickstart_file))
         self.kg.collect_data()
 
     def test_lvm_partitions(self):

--- a/tests/test_kickstart.py
+++ b/tests/test_kickstart.py
@@ -71,9 +71,9 @@ class TestKickstartPartitioning(base.TestCase):
                         os.path.join(self.WORKING_DIR, kickstart_file))
         shutil.copyfile(os.path.join(os.getcwd(), 'kickstart', default_ks),
                         os.path.join(self.WORKING_DIR, default_ks))
-        conf = {"force": True}
+        conf = {"y": True}
         dc = DummyConfKickstart(**conf)
-        cli_kickstart = CLIKickstart(["--force"])
+        cli_kickstart = CLIKickstart(["--assumeyes"])
         conf = ConfKickstart(cli_kickstart.opts, dc, cli_kickstart)
         app = KickstartGenerator(conf, settings.KS_DIR, settings.PREUPGRADE_KS)
         self.kg = KickstartGenerator(conf, self.WORKING_DIR, os.path.join(kickstart_file))


### PR DESCRIPTION
Signed-off-by: Petr Hracek <phracek@redhat.com>

This Pull Request will execute user defined scripts mentioned in "postinstall.d" directory on migrated system.

User/admin is inform in case "postinstall.d" is empty.

~~~
# preupg-kickstart-generator 
You did not specify any postinstall scripts. Include them to /root/preupgrade/postinstall.d 

Do you want to continue with kickstart generation without postinstall scripts? (Y/n)
~~~