### PR TITLE
fix XSL files to support new version of OpenSCAP

### DIFF
--- a/data/report/complex/xccdf-report-impl.xsl
+++ b/data/report/complex/xccdf-report-impl.xsl
@@ -647,11 +647,19 @@ Authors:
     <xsl:param name="sce-tmpl"/>
 
     <xsl:choose>
-        <xsl:when test="$check/cdf:check-import[@import-name = 'stdout']/text()">
-            <span class="label label-default"><abbr title="Script Check Engine stdout taken from check-import">SCE stdout</abbr></span>
-            <pre><code>
-                <xsl:value-of select="$check/cdf:check-import[@import-name = 'stdout']/text()"/>
-            </code></pre>
+        <xsl:when test="$check/cdf:check-import[@import-name = 'stdout']/text() or $check/cdf:check-import[@import-name = 'stderr']/text()">
+            <xsl:if test="$check/cdf:check-import[@import-name = 'stdout']/text()">
+                <span class="label label-default"><abbr title="Script Check Engine stdout taken from check-import">Additional output</abbr></span>
+                <pre><code>
+                    <xsl:value-of select="$check/cdf:check-import[@import-name = 'stdout']/text()"/>
+                </code></pre>
+            </xsl:if>
+            <xsl:if test="$check/cdf:check-import[@import-name = 'stderr']/text()">
+                <span class="label label-default"><abbr title="Script Check Engine stderr taken from check-import">Logs</abbr></span>
+                <pre><code>
+                    <xsl:value-of select="$check/cdf:check-import[@import-name = 'stderr']/text()"/>
+                </code></pre>
+            </xsl:if>
         </xsl:when>
         <xsl:otherwise>
             <xsl:variable name="filename">
@@ -663,11 +671,18 @@ Authors:
 
             <xsl:if test="$filename != ''">
                 <xsl:variable name="stdout" select="document($filename)/sceres:sce_results/sceres:stdout/text()"/>
+                <xsl:variable name="stderr" select="document($filename)/sceres:sce_results/sceres:stderr/text()"/>
 
                 <xsl:if test="normalize-space($stdout)">
-                    <span class="label label-default"><abbr title="Script Check Engine stdout taken from '{$filename}'">SCE stdout</abbr></span>
+                    <span class="label label-default"><abbr title="Script Check Engine stdout taken from '{$filename}'">Additional output</abbr></span>
                     <pre><code>
                         <xsl:copy-of select="$stdout"/>
+                    </code></pre>
+                </xsl:if>
+                <xsl:if test="normalize-space($stderr)">
+                    <span class="label label-default"><abbr title="Script Check Engine stderr taken from '{$filename}'">Logs</abbr></span>
+                    <pre><code>
+                        <xsl:copy-of select="$stderr"/>
                     </code></pre>
                 </xsl:if>
             </xsl:if>

--- a/data/report/simple/sce-report.xsl
+++ b/data/report/simple/sce-report.xsl
@@ -23,8 +23,8 @@ Authors:
 
 
 <xsl:stylesheet version="1.1"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-	xmlns="http://docbook.org/ns/docbook"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns="http://docbook.org/ns/docbook"
     xmlns:sceres="http://open-scap.org/page/SCE_result_file"
     xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1"
     >
@@ -37,6 +37,7 @@ Authors:
 
 <xsl:template mode='brief' match='sceres:sce_results'>
   <programlisting><xsl:value-of select='concat("&#10;", sceres:stdout/text())' /></programlisting>
+  <programlisting><xsl:value-of select='concat("&#10;", sceres:stderr/text())' /></programlisting>
 </xsl:template>
 
 </xsl:stylesheet>

--- a/data/report/simple/xccdf-report.xsl
+++ b/data/report/simple/xccdf-report.xsl
@@ -24,10 +24,10 @@ Authors:
 
 
 <xsl:stylesheet version="1.1"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-	xmlns:cdf="http://checklists.nist.gov/xccdf/1.1"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:cdf="http://checklists.nist.gov/xccdf/1.1"
     xmlns:exsl="http://exslt.org/common"
-	xmlns:db="http://docbook.org/ns/docbook"
+    xmlns:db="http://docbook.org/ns/docbook"
     xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns="http://docbook.org/ns/docbook"
     xmlns:s="http://open-scap.org/"
@@ -475,10 +475,19 @@ Authors:
 
 <xsl:template match='cdf:check-content-ref' mode='sce-engine-results'>
   <xsl:variable name='stdout-check-imports' select='../cdf:check-import[@import-name="stdout"]'/>
+  <xsl:variable name='stderr-check-imports' select='../cdf:check-import[@import-name="stderr"]'/>
 
-  <xsl:apply-templates select='$stdout-check-imports' mode='brief' />
+  <xsl:if test="$stdout-check-imports">
+      Additional output:
+      <xsl:apply-templates select='$stdout-check-imports' mode='brief' />
+  </xsl:if>
+  <xsl:if test="$stderr-check-imports">
+      Logs:
+      <xsl:apply-templates select='$stderr-check-imports' mode='brief' />
+  </xsl:if>
 
-<xsl:if test='not($stdout-check-imports)'>
+
+<xsl:if test='not($stdout-check-imports) and not($stderr-check-imports)'>
   <!-- fallback that looks for SCE result files -->
   <xsl:variable name='filename'>
     <xsl:choose>


### PR DESCRIPTION
Openscap will support split of stderr and stdout outputs instead
of one merged output as was before. XSL files are modified
to correctly handle this change and in addition are still compatible
with the old one.

In addition
  - stdout is presented as "Additional info"
  - stderr is presented as "Logs"
for better description for reader. And tabs were replaced by spaces.

TODO: Old-style report could be modified yet for better
      visualisation of these two "signs" - like changed color
      or something like that. But that's minor change to future.