### PR TITLE
remove 'component' from generated modules and tests

### DIFF
--- a/man/preupgrade-assistant-api.1
+++ b/man/preupgrade-assistant-api.1
@@ -91,7 +91,7 @@ Your script should also tell the administrator how risky it is to upgrade your c
 
 \fBneeds_action\fP - The test failed with the exit_fail return code but the module developer added the log_high_risk before exit_fail.
 
-\fBfail\fP - The test failed. The in-place upgrade is not recommended and marked as an EXTERME risk. 
+\fBfail\fP - The test failed. The in-place upgrade is not recommended and marked as an EXTERME risk.
 
 .SH RISK ASSESSMENT LEVELS
 The available risk assessment levels are:
@@ -110,11 +110,11 @@ The levels None, Slight and Medium change return code exit_fail to exit_needs_in
 
 There are several functions which do logging:
 
-\fBlog_{debug,info,warning,error} <component> <message>\fP
+\fBlog_{debug,info,warning,error} <message>\fP
 
 The function creates logs in the format:
 
-<SEVERITIES> <component> <TIMESTAMP> <MESSAGE>
+<SEVERITIES> <TIMESTAMP> <MESSAGE>
 
 .SH INI FILE EXAMPLE
 

--- a/preupg/ui/report/models.py
+++ b/preupg/ui/report/models.py
@@ -608,7 +608,7 @@ class TestLogMixin(object):
         create hostruns for list of hosts specified as Query in variable hosts
         """
         testlog_list = []
-        keys = ['component', 'date', 'level', 'message']
+        keys = ['date', 'level', 'message']
 
         for testlog in testlogs:
             testlog_dict = dict((key, testlog[key]) for key in keys if key in testlog)
@@ -630,14 +630,13 @@ class TestLogManager(models.Manager, TestLogMixin):
 class TestLog(models.Model):
     message = models.TextField()
     level = models.CharField(max_length=32)
-    component = models.CharField(max_length=255, null=True, blank=True)
     date = models.DateTimeField(null=True, blank=True)
     result = models.ForeignKey(TestResult)
 
     objects = TestLogManager()
 
     def __unicode__(self):
-        return u"%s %s %s %s" % (self.level, self.component, self.date, self.message)
+        return u"%s %s %s" % (self.level, self.date, self.message)
 
 
 class RiskMixin(object):

--- a/preupg/ui/report/processing.py
+++ b/preupg/ui/report/processing.py
@@ -184,7 +184,7 @@ class ReportParser(object):
         """
         parse test's logs; result is list of dicts:
         [
-            {'level': '', 'date': '', 'component': '', 'message': ''}
+            {'level': '', 'date': '', 'message': ''}
         ]
         """
         if not text:
@@ -192,7 +192,7 @@ class ReportParser(object):
         text = text.strip()
         lines = text.split('\n')
 
-        log_regex = "preupg\.log\.(?P<level>(ERROR|WARNING|INFO|DEBUG)): (?P<component>\S+): (?P<date_str>\S+) (?P<time>\S+) (?P<message>.+)"
+        log_regex = "preupg\.log\.(?P<level>(ERROR|WARNING|INFO|DEBUG)): (?P<date_str>\S+) (?P<time>\S+) (?P<message>.+)"
         risk_regex = "preupg\.risk\.(?P<level>\w+): (?P<message>.+)"
         date_format = '%Y-%m-%d %H:%M'
         logs = []

--- a/preupg/ui/report/south_migrations/0001_initial.py
+++ b/preupg/ui/report/south_migrations/0001_initial.py
@@ -126,7 +126,6 @@ class Migration(SchemaMigration):
             (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
             ('message', self.gf('django.db.models.fields.TextField')()),
             ('level', self.gf('django.db.models.fields.CharField')(max_length=32)),
-            ('component', self.gf('django.db.models.fields.CharField')(max_length=255, null=True, blank=True)),
             ('date', self.gf('django.db.models.fields.DateTimeField')(null=True, blank=True)),
             ('result', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['report.TestResult'])),
         ))
@@ -273,7 +272,6 @@ class Migration(SchemaMigration):
         },
         u'report.testlog': {
             'Meta': {'object_name': 'TestLog'},
-            'component': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
             'date': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'level': ('django.db.models.fields.CharField', [], {'max_length': '32'}),

--- a/preupg/ui/templates/report/test.html
+++ b/preupg/ui/templates/report/test.html
@@ -48,9 +48,6 @@
                                     Level
                                 </th>
                                 <th>
-                                    Component
-                                </th>
-                                <th>
                                     Message
                                 </th>
                             </tr>
@@ -60,7 +57,6 @@
                             <tr class="log">
                                 <td>{{ log.date }}</td>
                                 <td>{{ log.level }}</td>
-                                <td>{{ log.component }}</td>
                                 <td>{{ log.message }}</td>
                             </tr>
                             {% endfor %}

--- a/preupg/xmlgen/script_utils.py
+++ b/preupg/xmlgen/script_utils.py
@@ -135,14 +135,6 @@ class ModuleHelper(object):
                 new_line = '\n'.join(generated_section)
                 new_line = new_line.replace('<empty_line>', '').replace('<new_line>', '')
                 output_text += new_line+'\n'
-                if 'check_applies' in updates:
-                    component = updates['check_applies']
-                else:
-                    component = "distribution"
-                if script_type == "sh":
-                    output_text += 'COMPONENT="'+component+'"\n'
-                else:
-                    output_text += 'set_component("'+component+'")\n'
             output_text += line
         FileHelper.write_to_file(self.full_path_name, "wb", output_text)
 

--- a/tests/FOOBAR6_7/dummy/failed/dummy_failed.sh
+++ b/tests/FOOBAR6_7/dummy/failed/dummy_failed.sh
@@ -5,7 +5,6 @@ echo "Dummy failed test"
 
 
 . /usr/share/preupgrade/common.sh
-COMPONENT="distribution"
 #END GENERATED SECTION
 
 exit $XCCDF_RESULT_FAIL


### PR DESCRIPTION
And also from UI and man page.

This PR continues upon the already merged PR https://github.com/upgrades-migrations/preupgrade-assistant/pull/195.
Resolves: [rhbz#1372871](https://bugzilla.redhat.com/show_bug.cgi?id=1372871)