### PR TITLE
Don't use -E sed option (not working on RHEL 5)

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -540,7 +540,7 @@ conf_get_section() {
     while read line; do
         [ -z "$line" ] && continue
         echo "$line" | grep -q "^\[..*\]$" && {
-            _section="$(echo "$line" | sed -E "s/^\[(.+)\]$/\1/")"
+            _section="$(echo "$line" | sed -r "s/^\[(.+)\]$/\1/")"
             continue # that's new section
         }
         [ -z "$_section" ] && continue


### PR DESCRIPTION
Replace with -r which has the same meaning (extended regexp)

This option actually breaks execution of every module on RHEL 5.