### PR TITLE
Fix typo causing incomplete kickstart

### DIFF
--- a/preupg/kickstart/plugins/packages.py
+++ b/preupg/kickstart/plugins/packages.py
@@ -251,7 +251,7 @@ class PackagesHandling(BaseKickstart):
         except IOError:
             self.obsoleted = []
         try:
-            self.special_pkg_list = PackagesHandling.get_package_list('specifal_pkg_list')
+            self.special_pkg_list = PackagesHandling.get_package_list('special_pkg_list')
         except IOError:
             self.special_pkg_list = []
 


### PR DESCRIPTION
There's a typo which prevents reading special_pkg_list - that's a list of packages that modules decide to be added to kickstart.