### PR TITLE
RedHat -> Red Hat; remove RedHat from XCCDF template

### DIFF
--- a/data/templates/xccdf_template.xml
+++ b/data/templates/xccdf_template.xml
@@ -1,32 +1,21 @@
 <Benchmark xmlns:html="http://www.w3.org/1999/xhtml" xmlns:xf="http://preupgrade-assistant.org/wiki/XCCDF-fragment" xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_preupg-content_benchmark_all" xml:lang="en">
   <status date="${CURRENT_DATE}">draft</status>
-  <title>Preupgrade Assistant migration tool</title>
+  <title>Preupgrade Assistant analysis report</title>
   <description>
     <html:p>
-      This is a checklist of configuration settings intended to be used as RedHat Enterprise Linux migration tool.
-    </html:p>
-    <html:p>
-      The checklist can be processed by varius tools which enable users to:
-      <html:ul>
-        <html:li>define profiles with customized security policies,</html:li>
-        <html:li>audit systems to determine compliance with targeted security policy and</html:li>
-        <html:li>adjust system configuration.</html:li>
-      </html:ul>
+      This report lists results of a set of checks that have been performed on a system. Please go through the results and act according to the recommendations if given.
     </html:p>
   </description>
-  <notice id="disclaimer">This XCCDF has been automatically generated, it should only serve as a baseline!</notice>
+  <notice id="disclaimer">This report has been automatically generated.</notice>
 
   <front-matter></front-matter>
-
-  <reference href="http://iase.disa.mil/stigs/index.html">Defense Information Systems Agency - Security Technical Implementation Guides (DISA STIG)</reference>
-  <reference href="https://www.pcisecuritystandards.org">Payment Card Industry - Data Security Standard (PCI DSS)</reference>
 
   <platform idref="cpe:/o:PLATFORM_NAME:PLATFORM_ID" />
   <version>1.0</version>
   <model system="urn:xccdf:scoring:flat" />
 
   <Profile id="xccdf_preupg_profile_default">
-    <title>Preupgrade assistant default</title>
+    <title>Preupgrade Assistant default profile</title>
 
     <description>
       <html:p>

--- a/packaging/sources/preupgrade-assistant-scripts.patch
+++ b/packaging/sources/preupgrade-assistant-scripts.patch
@@ -10,4 +10,4 @@ index 80e2e33..755285c 100644
 +rpm -qal | sort=rpmtrackedfiles.log=RPMTRACKEDFILES=All installed files=YES=All_installed_files
 +for i in `df --local | rev | cut -f1 -d' ' | rev | tail -n +2`;do find $i -xdev -print; done | sort=allmyfiles.log=ALLMYFILES=All local files=NO
 +for i in `df --local | rev | cut -f1 -d' ' | rev | tail -n +2`;do find $i -xdev -executable -print; done | sort=executable.log=EXECUTABLES=All executable files=NO
-+grep -e "199e2f91fd431d51" -e "5326810137017186" -e "938a80caf21541eb" -e "fd372689897da07a" -e "45689c882fa658e0" rpm_qa.log=rpm_rhsigned.log=RPM_RHSIGNED_LOG=RedHat signed packages=NO
++grep -e "199e2f91fd431d51" -e "5326810137017186" -e "938a80caf21541eb" -e "fd372689897da07a" -e "45689c882fa658e0" rpm_qa.log=rpm_rhsigned.log=RPM_RHSIGNED_LOG=Red Hat signed packages=NO


### PR DESCRIPTION
- the text in XCCDF template updated to be comprehensible
- the RedHat to Red Hat change is related to [rhbz#1330454](https://bugzilla.redhat.com/show_bug.cgi?id=1330454)