### PR TITLE
Fix tempfile handling

### DIFF
--- a/preupg/utils.py
+++ b/preupg/utils.py
@@ -8,6 +8,7 @@ import fnmatch
 import os
 import sys
 import shutil
+import tempfile
 import mimetypes
 import platform
 import random
@@ -871,11 +872,11 @@ class OpenSCAPHelper(object):
         which was modified by preupgrade assistant
         """
         cmd = self.build_generate_command(xml_file, html_file, old_style=old_style)
-        generate_tempfile = os.path.join('/tmp', ''.join(random.SystemRandom().choice(string.ascii_letters)))
-        ret_val = ProcessHelper.run_subprocess(cmd, print_output=False, output=generate_tempfile)
-        if os.path.exists(generate_tempfile):
-            lines = FileHelper.get_file_content(generate_tempfile, 'r', method=True)
-            logger.debug('%s', '\n'.join(lines))
+        out_path = tempfile.mktemp(prefix='prefix.run_generate.')
+        ret_val = ProcessHelper.run_subprocess(cmd, print_output=False, output=out_path)
+        lines = FileHelper.get_file_content(out_path, 'r', method=True)
+        logger.debug('%s', '\n'.join(lines))
+        os.remove(out_path)
         return ret_val
 
 


### PR DESCRIPTION
The old version created temp file (used as cache between oscap and our
log file) file "manually" as random single-letter named file under /tmp
(explicitly).  Furthermore, these files (2 of them are created with each
preupg run) are not removed afterwards.

This is unsafe and messy.  Unsafe, because adversary could easily guess
temp file name and write to it between oscap ends and file is re-read
again.  Messy because we're leaving "anonynous" random files in temp.

The fix makes use of standard Python function `tempfile.mktemp()` to
handle the tempfile creation.  While the fiename is less predictable,
this is still not completely safe: `mktemp()` still suffers from the
race-condition risk.  mktemps() from the same module does solve it but
that's not usable with ProcessHelper/FileHelper, which force us to use
file paths instead of file descriptors.

Also the fix removes the temp file after run.

I have tested this on RHEL-5 and RHEL-6; just a single quick run with
--select-rule.