### PR TITLE
fix(2) patch for data/preassessment/scripts.txt

### DIFF
--- a/packaging/sources/preupgrade-assistant-scripts.patch
+++ b/packaging/sources/preupgrade-assistant-scripts.patch
@@ -8,6 +8,6 @@ index 80e2e33..755285c 100644
  getent group=group.log=GROUP=All groups=YES=Groups
 +chkconfig --list=chkconfig.log=CHKCONFIG=Service statuses=NO
 +rpm -qal | sort=rpmtrackedfiles.log=RPMTRACKEDFILES=All installed files=YES=All_installed_files
-+for i in `df --local | rev | cut -f1 -d' ' | rev | tail -n +2`;do find $i -xdev -print; done | sort=allmyfiles.log=ALLMYFILES=All local files=NO
-+for i in `df --local | rev | cut -f1 -d' ' | rev | tail -n +2`;do find $i -xdev -executable -print; done | sort=executable.log=EXECUTABLES=All executable files=NO
++for i in `df --local -P | rev | cut -f1 -d' ' | rev | tail -n +2`;do find $i -xdev -print; done | sort=allmyfiles.log=ALLMYFILES=All local files=NO
++for i in `df --local -P | rev | cut -f1 -d' ' | rev | tail -n +2`;do find $i -xdev -perm /111 -print; done | sort=executable.log=EXECUTABLES=All executable files=NO
 +grep -e "199e2f91fd431d51" -e "5326810137017186" -e "938a80caf21541eb" -e "fd372689897da07a" -e "45689c882fa658e0" rpm_qa.log=rpm_rhsigned.log=RPM_RHSIGNED_LOG=Red Hat signed packages=NO


### PR DESCRIPTION
In the patched data/preassessment/scripts.txt file on RHEL system
the "df" utility is used without "-P" option for POSIX format, that
guarantees each item of the output will be printed on the one line
only without wrapping. Otherwise the output can be wrapped
and generated data will be broken or incomplete in better case. This
commit fixes use of "df".

In addition, the "find" utility of version 4.2.27 (or lesser), does
not contain option "-executable", originally used in the scripts.txt
file. This is problematic on RHEL 5 system (or just systems which
uses too old find option). Instead of this, should be used:
   "-perm /111"
which is compatible with new version of the utility too.

** this should be finally the final patch of the "scripts.txt" file **