### PR TITLE
RHEL5: fix generating of report file

### DIFF
--- a/packaging/preupgrade-assistant.spec
+++ b/packaging/preupgrade-assistant.spec
@@ -48,6 +48,7 @@ Patch1:         crossarch_migration_support_check.patch
 Patch100:       preupgrade-assistant-six.patch
 Patch101:       preupgrade-assistant-python-2.4.patch
 Patch102:       preupgrade-assistant-pykickstart.patch
+Patch103:       preupgrade-assistant-xml-logs.patch
 %endif # RHEL <= 5
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
@@ -140,6 +141,7 @@ OpenSCAP is generated automatically.
 %patch100 -p1
 %patch101 -p1
 %patch102 -p1
+%patch103 -p1
 %endif # RHEL <= 5
 
 %build

--- a/packaging/sources/preupgrade-assistant-python-2.4.patch
+++ b/packaging/sources/preupgrade-assistant-python-2.4.patch
@@ -239,7 +239,7 @@ index cef8a3a..cf9344f 100644
      while True:
          if int(sys.version_info[0]) == 2:
 diff --git a/preupg/kickstart/application.py b/preupg/kickstart/application.py
-index 0a7c9a8..e0db0df 100644
+index 1f4cb28..cc0a313 100644
 --- a/preupg/kickstart/application.py
 +++ b/preupg/kickstart/application.py
 @@ -1,6 +1,4 @@
@@ -283,7 +283,7 @@ index 0a7c9a8..e0db0df 100644
          if tarball_content is not None:
              script_str = script_str.replace('{tar_ball}', base64.b64encode(tarball_content))
 diff --git a/preupg/logger.py b/preupg/logger.py
-index 8f12b78..ed61f22 100644
+index 8f12b78..349e402 100644
 --- a/preupg/logger.py
 +++ b/preupg/logger.py
 @@ -1,5 +1,4 @@
@@ -292,31 +292,46 @@ index 8f12b78..ed61f22 100644
  import logging
  import sys
  from preupg import settings
-@@ -68,8 +67,11 @@ def log_message(message, new_line=True, level=logging.INFO):
-             sys.stdout.write("\n")
-             sys.stdout.flush()
-     else:
+@@ -60,32 +59,22 @@ logger_report = LoggerHelper.get_basic_logger('preupgrade-assistant-report', log
+ 
+ def log_message(message, new_line=True, level=logging.INFO):
+     """ if verbose, log `msg % args` to stdout """
+-    if int(sys.version_info[0]) == 2:
+-        sys.stdout.write(message.encode(settings.defenc))
+-        sys.stdout.flush()
+-        # This is used in case that we do not want to print the new line
+-        if new_line:
+-            sys.stdout.write("\n")
+-            sys.stdout.flush()
+-    else:
 -        endline = "\n" if new_line else ""
 -        print(message, end=endline, file=sys.stdout, flush=True)
-+        if new_line:
-+            endline = "\n"
-+        else:
-+            endline = ""
-+        print(message)
++    sys.stdout.write(message.encode(settings.defenc))
++    # This is used in case that we do not want to print the new line
++    if new_line:
++        sys.stdout.write("\n")
++    sys.stdout.flush()
  
      logger_debug.log(level, message)
  
-@@ -84,8 +86,11 @@ def log_report_message(message, new_line=True, level=logging.INFO):
-             sys.stdout.write("\n")
-             sys.stdout.flush()
-     else:
+ 
+ def log_report_message(message, new_line=True, level=logging.INFO):
+     """ if verbose, log `msg % args` to stdout """
+-    if int(sys.version_info[0]) == 2:
+-        sys.stdout.write(message.encode(settings.defenc))
+-        sys.stdout.flush()
+-        # This is used in case that we do not want to print the new line
+-        if new_line:
+-            sys.stdout.write("\n")
+-            sys.stdout.flush()
+-    else:
 -        endline = "\n" if new_line else ""
 -        print(message, end=endline, file=sys.stdout, flush=True)
-+        if new_line:
-+            endline = "\n"
-+        else:
-+            endline = ""
-+        print(message)
++    sys.stdout.write(message.encode(settings.defenc))
++    # This is used in case that we do not want to print the new line
++    if new_line:
++        sys.stdout.write("\n")
++    sys.stdout.flush()
  
      logger_report.log(level, message)
  
@@ -371,7 +386,7 @@ index f107f36..7bccafc 100644
          old_width = self.width_size
          self.width_size -= 21
 diff --git a/preupg/script_api.py b/preupg/script_api.py
-index f7d2923..292ef34 100644
+index f7d2923..ca39e35 100644
 --- a/preupg/script_api.py
 +++ b/preupg/script_api.py
 @@ -19,7 +19,6 @@ These functions are available:
@@ -387,7 +402,7 @@ index f7d2923..292ef34 100644
      log risk level to stderr
      """
 -    print("preupg.risk.%s: %s\n" % (severity, message.encode(settings.defenc)), end="", file=sys.stderr)
-+    print("preupg.risk.%s: %s\n" % (severity, message.encode(settings.defenc)))
++    sys.stderr.write("preupg.risk.%s: %s\n" % (severity, message.encode(settings.defenc)))
  
  
  def log_extreme_risk(message):
@@ -396,7 +411,7 @@ index f7d2923..292ef34 100644
      :return:
      """
 -    print("preupg.log.%s: %s\n" % (severity, message.encode(settings.defenc)), end="", file=sys.stderr)
-+    print("preupg.log.%s: %s\n" % (severity, message.encode(settings.defenc)))
++    sys.stderr.write("preupg.log.%s: %s\n" % (severity, message.encode(settings.defenc)))
  
  
  def log_error(message):
@@ -487,7 +502,7 @@ index d702c6c..0ff6d2e 100644
  UPGRADE_PATH = ""
  KS_DIR = os.path.join(assessment_results_dir, 'kickstart')
 diff --git a/preupg/utils.py b/preupg/utils.py
-index 60aeb25..9467750 100644
+index 60aeb25..c21dc1f 100644
 --- a/preupg/utils.py
 +++ b/preupg/utils.py
 @@ -1,5 +1,4 @@
@@ -519,7 +534,7 @@ index 60aeb25..9467750 100644
              if function is None:
                  if print_output:
 -                    print (stdout_data, end="")
-+                    print stdout_data,
++                    sys.stdout.write(stdout_data)
                  else:
                      pass
              else:
@@ -724,7 +739,7 @@ index fc40369..3f753cc 100644
  
      def write_list_rules(self):
 diff --git a/preupg/xmlgen/script_utils.py b/preupg/xmlgen/script_utils.py
-index b23409e..aa4b1e1 100644
+index cd0e608..f34638c 100644
 --- a/preupg/xmlgen/script_utils.py
 +++ b/preupg/xmlgen/script_utils.py
 @@ -1,5 +1,3 @@

--- a/packaging/sources/preupgrade-assistant-xml-logs.patch
+++ b/packaging/sources/preupgrade-assistant-xml-logs.patch
@@ -32,7 +32,7 @@ index 1a9047c..7223bf4 100644
          """
          #Filter all rule-result in TestResult
          changed_fields = []
-+        self.fix_stderr(self) # it is ugly but command below too
++        self.fix_stderr() # it is ugly but command below too
          self.remove_empty_check_import()
          inplace_dict = {
              0: ReportHelper.upd_inspection,

--- a/packaging/sources/preupgrade-assistant-xml-logs.patch
+++ b/packaging/sources/preupgrade-assistant-xml-logs.patch
@@ -1,0 +1,38 @@
+diff --git a/preupg/report_parser.py b/preupg/report_parser.py
+index 1a9047c..7223bf4 100644
+--- a/preupg/report_parser.py
++++ b/preupg/report_parser.py
+@@ -198,6 +198,25 @@ class ReportParser(object):
+ 
+         self.write_xml()
+ 
++    def fix_stderr(self):
++        """The function transform stdout to stderr."""
++        for rule in self.get_all_result_rules():
++        # Filter all check-import=stdout which are empty and remove them
++            for check in self.get_nodes(rule, "check"):
++                cim_stdout = [x for x in self.get_nodes(check, "check-import")
++                                if x.get('import-name') == "stdout"]
++                cim_stderr = [x for x in self.get_nodes(check, "check-import")
++                                if x.get('import-name') == "stderr"]
++                if not cim_stdout or cim_stdout[0].text is None or cim_stdout[0].text == "":
++                    continue
++
++                # unexpected, but just to be sure..
++                if cim_stderr:
++                    if cim_stderr[0].text is not None and cim_stderr[0].text != "":
++                        cim_stdout[0].text +="\n"+cim_stderr[0].text
++                    remove_node(check, cim_stderr[0])
++                cim_stdout[0].set('import-name', "stderr")
++
+     def update_inplace_risk(self, scanning_progress, rule, res):
+         """Function updates inplace risk"""
+         inplace_risk = XccdfHelper.get_check_import_inplace_risk(rule)
+@@ -222,6 +241,7 @@ class ReportParser(object):
+         """
+         #Filter all rule-result in TestResult
+         changed_fields = []
++        self.fix_stderr(self) # it is ugly but command below too
+         self.remove_empty_check_import()
+         inplace_dict = {
+             0: ReportHelper.upd_inspection,


### PR DESCRIPTION
Previously there were use of python3 "print" function rewrite to use of python2 print function. But the rewrite changed the output, as there was used stdout instead of stderr sometimes; sometimes was produced string with two newlines ending instead of one newline character. This is fixed now.
 
The old openscap doesn't provide separately stderr and stdout output of each module and both merges into the stdout. Stderr is usually empty (or more precisely, contains whitespaces only).

To be more compatible with possible tests written on RHEL 6 system, merge stdout and stderr outputs in the results.xml file together as stderr and stdout remove.

I am not sure about possible outputs of OpenSCAP for all situations, so solution seems more ugly than it has to be.
