### PR TITLE
Fix logs and additional output in result file

### DIFF
--- a/data/report/simple/sce-report.xsl
+++ b/data/report/simple/sce-report.xsl
@@ -32,7 +32,7 @@ Authors:
 <!-- the concat workaround deals with preserved excessive whitespace -->
 
 <xsl:template mode='brief' match='xccdf:check-import'>
-  <programlisting><xsl:value-of select='concat("&#10;", text())' /></programlisting>
+  <programlisting><xsl:value-of select='text()' /></programlisting>
 </xsl:template>
 
 <xsl:template mode='brief' match='sceres:sce_results'>

--- a/data/report/simple/xccdf-report.xsl
+++ b/data/report/simple/xccdf-report.xsl
@@ -445,9 +445,7 @@ Authors:
 
 <!-- checking engine results related templates -->
 <xsl:template match='cdf:rule-result' mode='engine-results'>
-  <xsl:if test='contains(",fail,needs_inspection,needs_action,error,unknown,informational,", concat(",", normalize-space(cdf:result), ","))'>
-    <xsl:apply-templates mode='engine-results' select='cdf:check'/>
-  </xsl:if>
+  <xsl:apply-templates mode='engine-results' select='cdf:check'/>
 </xsl:template>
 
 <xsl:template match='cdf:check[starts-with(@system, "http://oval.mitre.org/XMLSchema/oval")]' mode='engine-results'>

--- a/preupg/application.py
+++ b/preupg/application.py
@@ -357,6 +357,9 @@ class Application(object):
         """The function prepares a XML file for HTML creation"""
         # Reload XML file
         self.report_parser.reload_xml(self.openscap_helper.get_default_xml_result_path())
+        # strip whitespaces on start and end of stdout/stderr from modules
+        # inside the result.xml file
+        self.report_parser.strip_whitespaces()
         # Replace fail in case of slight and medium risks with needs_inspection
         self.report_parser.replace_inplace_risk(scanning_results=self.scanning_progress)
         if not self.conf.debug:


### PR DESCRIPTION
**_result.xml_ tweaks:**
- Removed whitespace at the beginning and end of each module _stdout_ and _stderr_ (Additional info` and `Logs`).
- _stdout_ of modules is removed from the  _result.xml_ when it is empty, however _stderr_ wasn't. Now both of them are removed when empty.

**Simple style _result.html_ tweaks:**
- _stdout_ and _stderr_ are now left in the report no matter what the result of a module is. Before the output was not shown for `pass` and `fixed` results. The behaviour is now consistent with the complex report style.
- Remove an excessive newline from the beginning of each module _stdout_ and _stderr_ (`Additional info` and `Logs`).