### PR TITLE
Make naming of "return codes" consistent

### DIFF
--- a/bin/preupg
+++ b/bin/preupg
@@ -9,8 +9,6 @@ from preupg.conf import Conf
 from preupg import settings
 from preupg.logger import logger_debug
 
-#preupgrade_binary="/usr/bin/preupgrade-oscap"
-
 
 def main():
     cli = CLI()
@@ -22,7 +20,7 @@ def main():
     else:
         try:
             ret = app.run()
-            logger_debug.debug("Return value is '%s'", ret)
+            logger_debug.debug("Return code is '%s'", ret)
         except KeyboardInterrupt:
             print ('\nAssessment interrupted.')
             return 1

--- a/preupg/report_parser.py
+++ b/preupg/report_parser.py
@@ -206,7 +206,7 @@ class ReportParser(object):
         if inplace_risk:
             logger_report.debug("Update_inplace_risk '%s'", inplace_risk)
             return_value = XccdfHelper.get_and_print_inplace_risk(0, inplace_risk)
-            logger_report.debug("Get and print inplace risk return value '%s'", return_value)
+            logger_report.debug("Get and print inplace risk return code '%s'", return_value)
             if int(return_value)/2 == 1:
                 res.text = ReportHelper.get_needs_inspection()
             elif int(return_value)/2 == 2:

--- a/preupg/xccdf.py
+++ b/preupg/xccdf.py
@@ -72,7 +72,7 @@ class XccdfHelper(object):
         """
         The function read the content of the file
         and finds out all "preupg.risk" rows in TestResult tree.
-        return value is get from function get_and_print_inplace_risk
+        return code is get from function get_and_print_inplace_risk
         """
         message = "'preupg' command was not run yet. Run 'preupg' before getting list of risks."
         try:
@@ -89,7 +89,7 @@ class XccdfHelper(object):
         target_tree = ElementTree.fromstring(content)
         results = {}
         for profile in target_tree.findall(XMLNS + "TestResult"):
-            # Collect all inplace risk for each return values
+            # Collect all inplace risk for each return code
             for rule_result in profile.findall(XMLNS + "rule-result"):
                 result_value = None
                 for check in rule_result.findall(XMLNS + "result"):


### PR DESCRIPTION
- somewhere there is "return codes" used, on another places it's return state or return value - make it consistent
Related: rhbz#1414359