### PR TITLE
FileHelper.check_file: check type "int" instead of text types

### DIFF
--- a/packaging/sources/preupgrade-assistant-six.patch
+++ b/packaging/sources/preupgrade-assistant-six.patch
@@ -302,15 +302,6 @@ index 93619e9..8af2996 100644
  import datetime
  import re
  import subprocess
-@@ -92,7 +91,7 @@ class FileHelper(object):
-         with open mode)
-         """
-         intern_mode = 0
--        if isinstance(mode, six.text_type):
-+        if isinstance(mode, unicode):
-             if 'w' in mode or 'a' in mode:
-                 intern_mode += W_OK
-             if 'r' in mode:
 @@ -158,7 +157,7 @@ class FileHelper(object):
          script_types = {'/bin/bash': '.sh',
                          '/usr/bin/python': '.py',

--- a/preupg/utils.py
+++ b/preupg/utils.py
@@ -92,15 +92,15 @@ class FileHelper(object):
         with open mode)
         """
         intern_mode = 0
-        if isinstance(mode, six.text_type):
+        if isinstance(mode, int):
+            intern_mode = mode
+        else:
             if 'w' in mode or 'a' in mode:
                 intern_mode += W_OK
             if 'r' in mode:
                 intern_mode += R_OK
             if 'x' in mode:
                 intern_mode += X_OK
-        else:
-            intern_mode = mode
         if path.exists(fp):
             if path.isfile(fp):
                 if access(fp, intern_mode):


### PR DESCRIPTION
Check of the "int" type is much more transparent and issue-proof
then checking of variable text type.

In addition, it provides bug on some old systems, where the "str"
or the "unicode" type was used, based on unspecified settings
of system.