### PR TITLE
add fce add_pkg_to_kickstart into __all__ in py API

### DIFF
--- a/preupg/script_api.py
+++ b/preupg/script_api.py
@@ -62,6 +62,7 @@ __all__ = (
     'is_dist_native',
     'get_dist_native_list',
     'is_pkg_installed',
+    'add_pkg_to_kickstart',
     'deploy_hook',
 
     'PREUPGRADE_CACHE',


### PR DESCRIPTION
The *star* import of API for python modules doesn't include
the add_pkg_to_kickstart. (Fixed)