### PR TITLE
mitigate security issues in kickstart

### DIFF
--- a/data/templates/preupgrade.ks
+++ b/data/templates/preupgrade.ks
@@ -10,8 +10,10 @@ halt
 timezone Etc/UTC
 # System language
 lang en_US
+# Root password
+rootpw <password_placeholder>
 # System authorization information
-auth  --useshadow  --passalgo=sha512
+auth  --enableshadow --passalgo=sha512
 # enable firstboot
 firstboot --enable
 # SELinux configuration
@@ -19,9 +21,6 @@ selinux --enforcing
 
 # configure your networking properly
 network --onboot yes --device eth0 --bootproto dhcp
-
-# set root's password
-rootpw changethis
 
 # configure firewall
 firewall --service=ssh

--- a/preupg/kickstart/application.py
+++ b/preupg/kickstart/application.py
@@ -138,6 +138,18 @@ class KickstartGenerator(object):
         """ Remove obsolete items which does not exist on RHEL-7 anymore"""
         self.ks.handler.bootloader.location = None
 
+    def mitigate_security_issues(self):
+        """It may pose a security risk to put the root password into the
+        kickstart, even if it is a hash because weak hash algorithm could have
+        been used.
+        Also, set the default hashing algorithm for user passwords to the
+        strong sha-512.
+        """
+        self.ks.handler.rootpw(isCrypted=False,
+                               password="<password_placeholder>")
+        self.ks.handler.authconfig(
+            authconfig="--enableshadow --passalgo=sha512")
+
     def embed_script(self, tarball):
         if tarball is None:
             return
@@ -243,6 +255,7 @@ class KickstartGenerator(object):
         self.ks.handler.keyboard.keyboard = 'us'
         self.embed_script(self.latest_tarball)
         self.delete_obsolete_issues()
+        self.mitigate_security_issues()
         self.save_kickstart()
         self.comment_kickstart_issues()
         return True


### PR DESCRIPTION
- it may pose a security risk to put the root password into the
  kickstart - use a placeholder instead. User will need to fill
  in the password first before using the kickstart
- set the default hashing algorithm for user passwords to the
  strong sha-512.