### PR TITLE
kickstart: fix postmigrate template for kickstart

### DIFF
--- a/data/templates/postmigrate.sh
+++ b/data/templates/postmigrate.sh
@@ -26,7 +26,7 @@ do
     SAVE_PATH="${ABS_PATH}.preupg_save"
     if [[ -f "${ABS_PATH}" ]]
     then
-        echo "INFO: Back up new configuration file to '${SAVE_PATH}'." >> ${PREUPGRADE_LOG}
+        echo "INFO: Backing up the clean system configuration file '${ABS_PATH}' to '${SAVE_PATH}'." >> ${PREUPGRADE_LOG}
         cp -a ${ABS_PATH} ${SAVE_PATH}
     fi
 
@@ -37,7 +37,7 @@ do
         mkdir -p "$(dirname "$ABS_PATH")"
     fi
 
-    echo "INFO: Restore configuration file '${ABS_PATH}'." >> ${PREUPGRADE_LOG}
+    echo "INFO: Restoring configuration file of the migrated system '${ABS_PATH}'." >> ${PREUPGRADE_LOG}
     cp -a ${file} ${ABS_PATH}
     restorecon ${ABS_PATH}
 done

--- a/data/templates/postmigrate.sh
+++ b/data/templates/postmigrate.sh
@@ -13,6 +13,7 @@ tar --selinux -xzvf ${TAR_BALL}
 # create symlinks
 ln -s {RESULT_NAME}/cleanconf cleanconf
 ln -s {RESULT_NAME}/dirtyconf dirtyconf
+ln -s {RESULT_NAME}/kickstart kickstart
 ln -s {RESULT_NAME}/postmigrate.d postmigrate.d
 ln -s {RESULT_NAME}/noauto_postupgrade.d noauto_postupgrade.d
 

--- a/data/templates/postmigrate.sh
+++ b/data/templates/postmigrate.sh
@@ -5,38 +5,47 @@ cd ${TEMP_DIR}
 PREUPGRADE_LOG=/var/log/preupgrade.log
 touch ${PREUPGRADE_LOG}
 TAR_BALL=preupgrade.tar.gz
+echo "INFO: prepare tarball ${TAR_BALL}." >> ${PREUPGRADE_LOG}
 echo "{tar_ball}" > data
 base64 --decode data > ${TAR_BALL}
-tar -xzvf ${TAR_BALL}
+echo "INFO: unpack tarball ${TAR_BALL}." >> ${PREUPGRADE_LOG}
+tar --selinux -xzvf ${TAR_BALL}
+# create symlinks
 ln -s {RESULT_NAME}/cleanconf cleanconf
 ln -s {RESULT_NAME}/dirtyconf dirtyconf
+ln -s {RESULT_NAME}/postmigrate.d postmigrate.d
+ln -s {RESULT_NAME}/noauto_postupgrade.d noauto_postupgrade.d
+
 ls -laR >> ${PREUPGRADE_LOG}
-cd {RESULT_NAME}
-PWD=${pwd}
-cd cleanconf
+cd {RESULT_NAME}/cleanconf
+echo "INFO: Restore configuration files from ${PWD} directory." >> ${PREUPGRADE_LOG}
 for file in $(find . -type f)
 do
     ABS_PATH=${file:1}
-    SAVE_PATH="${ABS_PATH}.rpmsave"
-    DIFF_FILENAME="$(basename ${file}).diff"
-    echo "Comparing file ${file} against ${SAVE_PATH}" >> ${PREUPGRADE_LOG}
-    echo "Diff output is stored in ${TEMP_DIR}/${DIFF_FILENAME}" >> ${PREUPGRADE_LOG}
-    [[ -f ${ABS_PATH} ]] && \
+    SAVE_PATH="${ABS_PATH}.preupg_save"
+    if [[ -f "${ABS_PATH}" ]]
+    then
+        echo "INFO: Back up new configuration file to '${SAVE_PATH}'." >> ${PREUPGRADE_LOG}
         cp -a ${ABS_PATH} ${SAVE_PATH}
+    fi
+
+    if [[ ! -d "$(dirname "$ABS_PATH")" ]]
+    then
+        # create the directory - maybe doesn't exist yet because the rpm
+        # has not been installed yet
+        mkdir -p "$(dirname "$ABS_PATH")"
+    fi
+
+    echo "INFO: Restore configuration file '${ABS_PATH}'." >> ${PREUPGRADE_LOG}
     cp -a ${file} ${ABS_PATH}
     restorecon ${ABS_PATH}
-    if [[ -f ${SAVE_PATH} ]] && [[ -f ${ABS_PATH} ]]
-    then
-        diff -u ${ABS_PATH} ${SAVE_PATH} || diff -u ${ABS_PATH} ${SAVE_PATH} > ${TEMP_DIR}/${DIFF_FILENAME}
-    fi
 done
-cd ${PWD}
-POST_INSTALL_SCRIPTS="postmigrate.d"
-cd $POST_INSTALL_SCRIPTS
+
+echo "INFO: process postmigrate scripts." >> ${PREUPGRADE_LOG}
+cd ${TEMP_DIR}/{RESULT_NAME}/postmigrate.d
 for file in $(find . -type f -executable)
 do
     echo "Running script ${file} ..." >> ${PREUPGRADE_LOG}
     ${file}
     echo "Running script ${file} done" >> ${PREUPGRADE_LOG}
 done
-cd ${PWD}


### PR DESCRIPTION
- unpack tarball with '--selinux' option to keep original selinux
  context
- modified and added log messages
- remove creating of ".diff" files when restore cleanconf configs
  - WHY:
    - the files would be overwritten when some configuration files
      have same names but different paths
    - the log file was messy because of trailing diff output
    - admin is able to create diff of the modified files
      very simply
- backup original files with suffix .preupg_save instead of .rpmsave
  which could be rewritten during installation/update of new
  packages

- fix paths for
- create symlinks for other important directories
  - added: noauto_postupgrade.d, postmigrate.d
    (we can discuss creation of symlinks for all 'main' directories
     in /root/preupgrade)