### PR TITLE
remove the BEL characters when reloads XML file

### DIFF
--- a/preupg/report_parser.py
+++ b/preupg/report_parser.py
@@ -106,7 +106,11 @@ class ReportParser(object):
         content = FileHelper.get_file_content(self.path, 'rb', False, False)
         if not content:
             return None
-        self.target_tree = ElementTree.fromstring(content)
+
+        # remove the BEL characters from the loaded string, because
+        # this character causes crash of the parsing function of ElementTree
+        # when it occurs
+        self.target_tree = ElementTree.fromstring(content.replace("\a", ""))
 
     def get_select_rules(self):
         selected = self.filter_grandchildren(self.target_tree, self.profile, "select")


### PR DESCRIPTION
The OpenSCAP put whole stdout/stderr into the result.xml directly
so we are not able to handle these outputs. In case that the BEL
character is produced by some utility (it happened already), parsing
of XML file fails.

NOTE: Some XML libraries handle it already, but not the one, used
      by the PA, mainly on older systems