### PR TITLE
remove question with no postmigrate.d script

### DIFF
--- a/preupg/kickstart/application.py
+++ b/preupg/kickstart/application.py
@@ -235,28 +235,9 @@ class KickstartGenerator(object):
                 kickstart_data[index] = "#" + row
         FileHelper.write_to_file(self.kickstart_name, 'wb', kickstart_data)
 
-    def check_postmigrate_dir(self):
-        if not FileHelper.get_list_executable_files_in_dir(os.path.join(settings.assessment_results_dir,
-                                                                        settings.postmigrate_dir)):
-            if not self.conf.assumeyes:
-                accept = ['y', 'yes']
-                log_message("The '%s' folder is empty - scripts to be"
-                            " executed after the migration should be placed"
-                            " here." % os.path.join(
-                                settings.assessment_results_dir,
-                                settings.postmigrate_dir))
-                message = "Do you want to continue with kickstart " \
-                          "generation without any postmigration scripts?"
-                choice = MessageHelper.get_message(message=message, prompt="(Y/n)")
-                if choice.lower() not in accept:
-                    return None
-        return True
-
     def generate(self):
         if not self.collect_data():
             log_message("Important data are missing for the Kickstart generation.", level=logging.ERROR)
-            return None
-        if not self.check_postmigrate_dir():
             return None
         self.ks.handler.packages.excludedList = []
         self.plugin_classes = self.load_plugins(os.path.dirname(__file__))


### PR DESCRIPTION
- when generating kickstart there was a question to
  the user whether to proceed in case there were no
  scripts in the /root/preupgrade/postmigrate.d
  directory. This directory was supposed to be used
  by the user if they wanted to add any custom script
  to be run after the migration. However it doesn't
  work - if the user adds any script there, it doesn't
  get into the generated kickstart. Since this feature
  is not documented anywhere it's best to remove the
  question for now.