### PR TITLE
Add possibility to change data_dir with env variable

### DIFF
--- a/preupg/settings.py
+++ b/preupg/settings.py
@@ -36,6 +36,9 @@ share_dir = "/usr/share"
 source_dir = os.path.join(share_dir, prefix)
 
 data_dir = os.path.join(source_dir, "data")
+# set data_dir value based on env variable PREUPG_DATA_DIR
+# if variable is not set doesn't change the value
+data_dir = os.getenv('PREUPG_DATA_DIR', data_dir)
 
 # file where the lock file stored
 lock_file = "/var/run/preupgrade.pid"


### PR DESCRIPTION
**Problem:**
    Preupgrade Assistant tools in this moment depend on hardcoded paths
    from setting.py including data_dir, which points to
    '/usr/share/preupgrade/data'. When PA isn't installed on the system
    and developer wants to test a new code(e.g. run xccdf-compose) he
    needs to edit setting.py in order to change data_dir variable.
**Solution:**
    To be able to override this data_dir variable with environment
    variable "PREUPG_DATA_DIR" instead of changing setting.py