### PR TITLE
Update xccdf_template.xml

### DIFF
--- a/data/templates/xccdf_template.xml
+++ b/data/templates/xccdf_template.xml
@@ -2,9 +2,9 @@
   <status date="${CURRENT_DATE}">draft</status>
   <title>Preupgrade Assistant analysis report</title>
   <description>
-    <p>
+    <html:p>
       This report lists results of a set of checks that have been performed on a system. Please go through the results and act according to the recommendations if given.
-    </p>
+    </html:p>
   </description>
   <notice id="disclaimer">This report has been automatically generated.</notice>
 
@@ -18,9 +18,9 @@
     <title>Preupgrade Assistant default profile</title>
 
     <description>
-      <p>
+      <html:p>
         This profile is designed for the Preupgrade Assistant tool.
-      </p>
+      </html:p>
     </description>
   </Profile>
 </Benchmark>


### PR DESCRIPTION
Merged PR https://github.com/upgrades-migrations/preupgrade-assistant/pull/216 introduced an incorrect update to the xccdf_template.xml - _html_ namespace was removed from \<p\> tags. However, internally, OpenSCAP validates the _all_xccdf.xml_ generated from a module set and this validation fails. It does expect \<html:*\> tags, i.e. \<html:p\> was correct in the template.