### PR TITLE
Fix generating Preupgrade Assistant modules

### DIFF
--- a/preupg/xmlgen/xml_tags.py
+++ b/preupg/xmlgen/xml_tags.py
@@ -58,8 +58,8 @@ CONFIG_SECTION = """
             File(s) affected:
             <ul>
             {config_file}
-            <ul>
-        <p>
+            </ul>
+        </p>
 """
 RULE_SECTION_VALUE_IMPORT = """\t\t<check-import import-name="stderr"/>"""
 


### PR DESCRIPTION
When generating module set for Preupgrade Assistant using _tools/preupg-xccdf-compose_, XML parse errors were occuring.
Error example:
```
Encountered a parse error in file /home/mbocek/.../RHEL5_7-results/services/pki/pki-ca/group.xml.
Details: mismatched tag: line 42, column 8
```
It was due to unclosed HTML tags in generated group.xmls.