### PR TITLE
Remove obsolete variable from spec

### DIFF
--- a/packaging/preupgrade-assistant.spec
+++ b/packaging/preupgrade-assistant.spec
@@ -186,9 +186,9 @@ get_file_list() {
         | grep -vE "$3" | sed "$4" >> $5
 }
 ### preupgrade-assistant ###
-get_file_list f %{python_sitelib}/.*$  "%{bundled_pykickstart_dirname}|preupg/(ui|creator)|\.pyc$" \
+get_file_list f %{python_sitelib}/.*$  "preupg/(ui|creator)|\.pyc$" \
     "s/\.py$/\.py\*/" preupg-filelist
-get_file_list d %{python_sitelib}/.*$ "%{bundled_pykickstart_dirname}|preupg/(ui|creator)|\.pyc$" \
+get_file_list d %{python_sitelib}/.*$ "preupg/(ui|creator)|\.pyc$" \
     "s/^/\%dir /" preupg-filelist
 %if %{build_ui}
 ### preupgrade-assistant-ui ###


### PR DESCRIPTION
- bundled_pykickstart_dirname variable should have been
  removed in previous commits removing RHEL 5 code but was
  left here by mistake