### PR TITLE
Revert back removed xhtml namespace

### DIFF
--- a/preupg/xmlgen/xml_tags.py
+++ b/preupg/xmlgen/xml_tags.py
@@ -53,13 +53,14 @@ FIX = """<fix """+PLATFORM+""" system="urn:xccdf:fix:script:{script_type}">
 {solution}
          </fix>"""
 FIX_TEXT = """<fixtext>{solution_text}</fixtext>"""
+
 CONFIG_SECTION = """
-        <p>
+        <xhtml:p>
             File(s) affected:
-            <ul>
+            <xhtml:ul>
             {config_file}
-            </ul>
-        </p>
+            </xhtml:ul>
+        </xhtml:p>
 """
 RULE_SECTION_VALUE_IMPORT = """\t\t<check-import import-name="stderr"/>"""
 

--- a/preupg/xmlgen/xml_utils.py
+++ b/preupg/xmlgen/xml_utils.py
@@ -72,12 +72,14 @@ class XmlUtils(object):
         lines = FileHelper.get_file_content(os.path.join(self.dirname,
                                                          filename), "rb", True)
 
-        bold = '<b>{0}</b>'
-        br = '<br/>'
-        table_begin = '<table>'
-        table_end = '</table>'
-        table_header = '<tr><th>Result</th><th>Description</th></tr>'
-        table_row = '<tr><td>{0}</td><td>{1}</td></tr>'
+        bold = '<xhtml:b>{0}</xhtml:b>'
+        br = '<xhtml:br/>'
+        table_begin = '<xhtml:table>'
+        table_end = '</xhtml:table>'
+        table_header = '<xhtml:tr><xhtml:th>Result</xhtml:th><xhtml:th>' \
+                       'Description</xhtml:th></xhtml:tr>'
+        table_row = '<xhtml:tr><xhtml:td>{0}</xhtml:td><xhtml:td>{1}' \
+                    '</xhtml:td></xhtml:tr>'
         new_text.append(br + br + '\n' + bold.format('Details:') + br)
         results = False
         for line in lines:
@@ -112,7 +114,7 @@ class XmlUtils(object):
         elif search_exp == "{config_file}":
             new_text = ""
             for lines in replace_exp.split(','):
-                new_text += "<li>" + lines.strip() + "</li>"
+                new_text += "<xhtml:li>" + lines.strip() + "</xhtml:li>"
             replace_exp = new_text.rstrip()
         elif search_exp == "{solution}":
             new_text = FileHelper.get_file_content(os.path.join(

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -277,7 +277,7 @@ A solution text for test suite"
         self.assertTrue(rule_title)
 
     def test_xml_config_file(self):
-        conf_file = [x for x in self.rule if "<li>/etc/named.conf</li>" in x]
+        conf_file = [x for x in self.rule if "<xhtml:li>/etc/named.conf</xhtml:li>" in x]
         self.assertTrue(conf_file)
 
     def test_xml_fix_text(self):


### PR DESCRIPTION
- without it, the default ns0 is used, which is openscap namespace
  and this namespace doesn't define html tags - that leads to crash
  during the xml parsing