### PR TITLE
Fix running third party modules

### DIFF
--- a/preupg/application.py
+++ b/preupg/application.py
@@ -391,7 +391,7 @@ class Application(object):
         3rd party contents are stored in
         /usr/share/preupgrade/RHEL6_7/3rdparty directory
         """
-        for third_party, content in iter(list_contents(dir_name.items())):
+        for third_party, content in list_contents(dir_name).items():
             third_party_name = self.third_party = third_party
             log_message("Execution {0} assessments:".format(third_party))
             self.report_parser.reload_xml(content)


### PR DESCRIPTION
In one of the previous commits (https://github.com/upgrades-migrations/preupgrade-assistant/commit/817fe90d50f022db36db5a38b96faef11c2c23ad#diff-cd214281061a49f12a09f465b45bc87bR395) an issue was introduces when _.items()_ function was misplaced - used on a string instead of a list.
It was causing an error:
```
140/140 ...done    (The NIS server configuration file)
The assessment finished (time 02:58s)

Traceback (most recent call last):
  File "/usr/bin/preupg", line 19, in main
    return_code = app.run()
  File "/usr/lib/python2.6/site-packages/preupg/application.py", line 746, in run
    retval = self.scan_system()
  File "/usr/lib/python2.6/site-packages/preupg/application.py", line 520, in scan_system
    self.run_third_party_modules(third_party_dir_name)
  File "/usr/lib/python2.6/site-packages/preupg/application.py", line 394, in run_third_party_modules
    for third_party, content in iter(list_contents(dir_name.items())):
AttributeError: 'unicode' object has no attribute 'items'
```