### PR TITLE
Update copy_clean_conf.sh

### DIFF
--- a/data/postupgrade.d/copy_clean_conf.sh
+++ b/data/postupgrade.d/copy_clean_conf.sh
@@ -19,6 +19,6 @@ do
         echo "Config file $NEW_FILE does not exists."
     fi
     echo "Copy file $file to $NEW_FILE"
-    cp $file $NEW_FILE
+    cp -a $file $NEW_FILE
 done
 cd "$CWD"


### PR DESCRIPTION
When executing _copy_clean_conf.sh_ during the upgrade phase (by redhat-upgrade-dracut) the config files stored in /root/preupgrade/cleanconf are not copied to the original location with the original ownership.

This has caused issues with bind after the upgrade: https://bugzilla.redhat.com/show_bug.cgi?id=1416324#c9