### PR TITLE
Allow using -u option without -r

### DIFF
--- a/preupg/application.py
+++ b/preupg/application.py
@@ -629,7 +629,7 @@ class Application(object):
             log_message('\n'.join(rules))
             return 0
 
-        if self.conf.upload:
+        if self.conf.upload and self.conf.results:
             if not self.upload_results():
                 return ReturnValues.SEND_REPORT_TO_UI
             return 0


### PR DESCRIPTION
Fixes running Preupgrade Assistant when running it with just a _-u_ option:
`preupg -u http://hostname:8099/submit`
This is a basic command that used to work and is documented on many places. So this is a high priority one.

Resolves: [rhbz#1391968](https://bugzilla.redhat.com/show_bug.cgi?id=1391968)