### PR TITLE
Return code 28 instead of 0-2 when upload fails

### DIFF
--- a/man/preupg.1
+++ b/man/preupg.1
@@ -147,7 +147,7 @@ Possible return codes are:
 
 27 - The /usr/share/preupgrade/data/preassessment/scripts.txt file is missing. The Preupgrade Assistant is not installed properly and needs to be reinstalled.
 
-28 - We have detected some troubles with sending the report to WEB-UI. Check if it is installed.
+28 - We have detected some troubles with sending the report to WEB-UI.
 
 29 - Internal problem.
 

--- a/preupg/application.py
+++ b/preupg/application.py
@@ -153,7 +153,7 @@ class Application(object):
         return os.path.join(self.conf.assessment_results_dir,
                             settings.postupgrade_dir)
 
-    def upload_results(self, tarball_path=None):
+    def upload_results(self):
         """upload tarball with results to frontend"""
         import xmlrpclib
         import socket
@@ -188,6 +188,8 @@ class Application(object):
         else:
             tarball_results = self.conf.results
         if tarball_results is None or not os.path.exists(tarball_results):
+            log_message("Can't determine what tarball to upload to the UI.",
+                        level=logging.ERROR)
             return False
         file_content = FileHelper.get_file_content(tarball_results, 'rb',
                                                    False, False)
@@ -204,6 +206,7 @@ class Application(object):
             log_message('Invalid response from the server.')
             log_message("Invalid response from the server: %s"
                         % response, level=logging.ERROR)
+            return False
         else:
             if status == 'OK':
                 try:
@@ -220,6 +223,8 @@ class Application(object):
                 except KeyError:
                     log_message('The report not submitted. The server returned a status: ', status)
                     log_message("The report status: %s" % status, level=logging.ERROR)
+                return False
+        return True
 
     def prepare_scan_directories(self):
         """Used for prepartion of directories used during scan functionality"""
@@ -740,7 +745,7 @@ class Application(object):
             KickstartGenerator.kickstart_scripts()
             FileHelper.remove_home_issues()
             if self.conf.upload:
-                if not self.upload_results(self.tar_ball_name):
+                if not self.upload_results():
                     retval = ReturnValues.SEND_REPORT_TO_UI
             os.chdir(current_dir)
             return retval


### PR DESCRIPTION
Return value of the function that uploads results (_Application.upload_results()_) to the WEB-UI server was not checked so Preupgrade Assistant didn't provide information to the user when the upload failed.

Related: rhbz#[1391968](https://bugzilla.redhat.com/show_bug.cgi?id=1391968)