### PR TITLE
Remove CPE platform from the result report

### DIFF
--- a/data/report/complex/xccdf-report-impl.xsl
+++ b/data/report/complex/xccdf-report-impl.xsl
@@ -129,29 +129,6 @@ Authors:
                     </tr>
                 </table>
             </div>
-            <div class="col-md-3 horizontal-scroll">
-                <h4>CPE Platforms</h4>
-                <ul class="list-group">
-                    <!-- all the applicable platforms first -->
-                    <xsl:for-each select="$benchmark/cdf:platform">
-                        <xsl:variable name="idref" select="@idref"/>
-                        <xsl:if test="$testresult/cdf:platform[@idref=$idref]">
-                            <li class="list-group-item">
-                                <span class="label label-success" title="CPE platform {@idref} was found applicable on the evaluated machine"><xsl:value-of select="@idref"/></span>
-                            </li>
-                        </xsl:if>
-                    </xsl:for-each>
-                    <!-- then the rest -->
-                    <xsl:for-each select="$benchmark/cdf:platform">
-                        <xsl:variable name="idref" select="@idref"/>
-                        <xsl:if test="not($testresult/cdf:platform[@idref=$idref])">
-                            <li class="list-group-item">
-                                <span class="label label-default" title="This CPE platform was not applicable on the evaluated machine"><xsl:value-of select="@idref"/></span>
-                            </li>
-                        </xsl:if>
-                    </xsl:for-each>
-                </ul>
-            </div>
             <div class="col-md-4 horizontal-scroll">
                 <h4>Addresses</h4>
                 <ul class="list-group">

--- a/data/templates/xccdf_template.xml
+++ b/data/templates/xccdf_template.xml
@@ -10,7 +10,6 @@
 
   <front-matter></front-matter>
 
-  <platform idref="cpe:/o:PLATFORM_NAME:PLATFORM_ID" />
   <version>1.0</version>
   <model system="urn:xccdf:scoring:flat" />
 

--- a/preupg/application.py
+++ b/preupg/application.py
@@ -477,18 +477,9 @@ class Application(object):
             shutil.move(xccdf_compose.get_compose_dir_name(), self.assessment_dir)
 
         self.common.prep_symlinks(self.assessment_dir,
-                                  scenario=self.get_proper_scenario(scenario))
-        if not self.conf.contents:
-            ret = XccdfHelper.update_platform(os.path.join(
-                    self.assessment_dir, settings.content_file))
-            if ret:
-                log_message(str(ret), level=logging.ERROR)
-                return ReturnValues.SCENARIO
-        else:
-            ret = XccdfHelper.update_platform(self.content)
-            if ret:
-                log_message(str(ret), level=logging.ERROR)
-                return ReturnValues.SCENARIO
+                                  scenario=self.get_proper_scenario(scenario))            
+
+        if self.conf.contents:
             self.assessment_dir = os.path.dirname(self.content)
         return 0
 
@@ -529,7 +520,6 @@ class Application(object):
             except EnvironmentError as err:
                 log_message(str(err), level=logging.ERROR)
                 return ReturnValues.SCENARIO
-            self.report_parser.modify_platform_tag(version[0])
         if self.conf.mode:
             lines = [i.rstrip() for i in
                      FileHelper.get_file_content(

--- a/preupg/report_parser.py
+++ b/preupg/report_parser.py
@@ -188,15 +188,6 @@ class ReportParser(object):
 
         self.write_xml()
 
-    def modify_platform_tag(self, platform_tag):
-        """The function updates platform tag to the assessment system tag"""
-        for platform in self.filter_children(self.target_tree, "platform"):
-            if "cpe:/o:redhat:enterprise_linux:" in platform.get("idref"):
-                logger_report.debug("Update platform tag to '%s'", platform_tag)
-                platform.set("idref", "cpe:/o:redhat:enterprise_linux:"+platform_tag)
-
-        self.write_xml()
-
     def update_inplace_risk(self, scanning_progress, rule, res):
         """Function updates inplace risk"""
         inplace_risk = XccdfHelper.get_check_import_inplace_risk(rule)

--- a/preupg/settings.py
+++ b/preupg/settings.py
@@ -184,8 +184,6 @@ KS_TEMPLATES = [KS_TEMPLATE, KS_POSTSCRIPT_TEMPLATE]
 KS_FILES = ['default_grouplist-el7', 'default-optional_grouplist-el7']
 KS_SCRIPTS = "kickstart_scripts.txt"
 
-CPE_RHEL = 'redhat:enterprise_linux'
-CPE_FEDORA = 'fedoraproject:fedora'
 PREUPG_CONFIG_FILE = os.path.join('/etc', 'preupgrade-assistant.conf')
 
 DEVEL_MODE = os.path.join(cache_dir, 'devel_mode')

--- a/preupg/utils.py
+++ b/preupg/utils.py
@@ -392,16 +392,6 @@ class PreupgHelper(object):
 class SystemIdentification(object):
 
     @staticmethod
-    def get_system():
-        """
-        Check if system is Fedora or RHEL
-
-        :return: Fedora or None
-        """
-        lines = FileHelper.get_file_content('/etc/redhat-release', 'rb', method=True)
-        return [line for line in lines if line.startswith('Fedora')]
-
-    @staticmethod
     def get_arch():
         return platform.machine()
 

--- a/preupg/xccdf.py
+++ b/preupg/xccdf.py
@@ -144,25 +144,3 @@ class XccdfHelper(object):
         rules = FileHelper.get_file_content(os.path.join(main_dir, settings.file_list_rules), "rb", method=True)
         rules = [x.strip() for x in rules]
         return rules
-
-    @staticmethod
-    def update_platform(full_path):
-        file_lines = FileHelper.get_file_content(full_path, 'rb', method=True)
-        platform = ''
-        platform_id = ''
-        if not SystemIdentification.get_system():
-            platform = settings.CPE_RHEL
-        else:
-            platform = settings.CPE_FEDORA
-        try:
-            platform_id = ModuleSetUtils.get_module_set_os_versions(
-                os.path.dirname(full_path))
-        except EnvironmentError as err:
-            return err
-        for index, line in enumerate(file_lines):
-            if 'PLATFORM_NAME' in line:
-                line = line.replace('PLATFORM_NAME', platform)
-            if 'PLATFORM_ID' in line:
-                line = line.replace('PLATFORM_ID', platform_id[0])
-            file_lines[index] = line
-        FileHelper.write_to_file(full_path, 'wb', file_lines)

--- a/preupg/xmlgen/xml_tags.py
+++ b/preupg/xmlgen/xml_tags.py
@@ -48,8 +48,7 @@ RULE_SECTION = """
       </check>
     </Rule>
 """
-PLATFORM = """platform=\"cpe:/o:PLATFORM_NAME:PLATFORM_ID\""""
-FIX = """<fix """+PLATFORM+""" system="urn:xccdf:fix:script:{script_type}">
+FIX = """<fix system="urn:xccdf:fix:script:{script_type}">
 {solution}
          </fix>"""
 FIX_TEXT = """<fixtext>{solution_text}</fixtext>"""

--- a/preupg/xmlgen/xml_utils.py
+++ b/preupg/xmlgen/xml_utils.py
@@ -286,9 +286,6 @@ class XmlUtils(object):
         else:
             self.update_values_list(self.rule, "{fix}", xml_tags.FIX_TEXT)
             self.update_values_list(self.rule, "{solution_text}", "text")
-            self.update_values_list(
-                self.rule, "{platform_id}",
-                ModuleSetUtils.get_module_set_os_versions(self.module_dir)[1])
 
     def fnc_update_mode(self, key, name):
         """

--- a/tests/generated_results/inplace_combined_risk_test.xml
+++ b/tests/generated_results/inplace_combined_risk_test.xml
@@ -18,7 +18,6 @@
   <ns0:front-matter xml:lang="en" />
   <ns0:reference href="http://iase.disa.mil/stigs/index.html">Defense Information Systems Agency - Security Technical Implementation Guides (DISA STIG)</ns0:reference>
   <ns0:reference href="https://www.pcisecuritystandards.org">Payment Card Industry - Data Security Standard (PCI DSS)</ns0:reference>
-  <ns0:platform idref="cpe:/o:PLATFORM_TAG:6" />
   <ns0:version>1.0</ns0:version>
   <ns0:model system="urn:xccdf:scoring:default" />
   <ns0:model system="urn:xccdf:scoring:flat" />

--- a/tests/generated_results/inplace_risk_test.xml
+++ b/tests/generated_results/inplace_risk_test.xml
@@ -18,7 +18,6 @@
   <ns0:front-matter xml:lang="en" />
   <ns0:reference href="http://iase.disa.mil/stigs/index.html">Defense Information Systems Agency - Security Technical Implementation Guides (DISA STIG)</ns0:reference>
   <ns0:reference href="https://www.pcisecuritystandards.org">Payment Card Industry - Data Security Standard (PCI DSS)</ns0:reference>
-  <ns0:platform idref="cpe:/o:PLATFORM_TAG:6" />
   <ns0:version>1.0</ns0:version>
   <ns0:model system="urn:xccdf:scoring:default" />
   <ns0:model system="urn:xccdf:scoring:flat" />

--- a/tests/test_preupg.py
+++ b/tests/test_preupg.py
@@ -130,17 +130,6 @@ class TestXMLUpdates(base.TestCase):
     def tearDown(self):
         os.remove(self.test_content)
 
-    def test_platform_tag(self):
-        shutil.copyfile(self.content, self.test_content)
-        rp = ReportParser(self.test_content)
-        rp.modify_platform_tag("12")
-
-        found = 0
-        for platform in rp.get_nodes(rp.target_tree, "platform"):
-            if "cpe:/o:redhat:enterprise_linux:12" in platform.get('idref'):
-                found = 1
-        self.assertTrue(found)
-
     def test_result_dirs_tmp_preupgrade(self):
         shutil.copyfile(self.content, self.test_content)
         rp = ReportParser(self.test_content)


### PR DESCRIPTION
Preupgrade Assistant was setting the CPE platform (standardized OS identification) in the module set _all-xccdf.xml_.
Also, in case the _--contents_ option was used, Preupgrade Assistant was setting the CPE platform in the original module set _all-xccdf.xml_, which is  definitely not OK.
There is no need for the CPE in the report, the information doesn't have any value for the user. And when user faces a problem with the tool, the Red Hat support requests _sosreport_ which contains the identification of the OS.
Related issue: #247