### PR TITLE
Do not corrupt custom module set all-xccdf.xml

### DIFF
--- a/preupg/application.py
+++ b/preupg/application.py
@@ -483,8 +483,6 @@ class Application(object):
                 shutil.rmtree(self.assessment_dir)
             shutil.move(xccdf_compose.get_compose_dir_name(), self.assessment_dir)
         self.run_init()
-        if self.conf.contents:
-            self.assessment_dir = os.path.dirname(self.content)
         return 0
 
     def run_init(self):


### PR DESCRIPTION
Preupgrade Assistant was corrupting module set _all-xccdf.xml_ in case the module set path was specified through the _--contents_ option.
Resolves rhbz#[1368823](https://bugzilla.redhat.com/show_bug.cgi?id=1368823)
Resolves #247