### PR TITLE
Dir name dependent tags in generated xml files with xccdf-compose

### DIFF
--- a/preupg/xmlgen/compose.py
+++ b/preupg/xmlgen/compose.py
@@ -83,7 +83,7 @@ class ComposeXML(object):
         Find group.xml file recursively through all module directories
         and modules. Collect data from each of them into dictionary.
 
-        @parma {str} root_module_dir - directory where all modules are stored
+        @param {str} root_module_dir - directory where all modules are stored
         @param {str} source_dir - directory path for processing
         @param {str} content - module result e.g. failed,needs_action,pass,...
         @param {int} level - indicate the depth of recursive call in directory

--- a/preupg/xmlgen/compose.py
+++ b/preupg/xmlgen/compose.py
@@ -77,16 +77,15 @@ class XCCDFCompose(object):
 class ComposeXML(object):
 
     @staticmethod
-    def collect_group_xmls(root_module_dir, source_dir, content=None, level=0,
+    def collect_group_xmls(module_set_dir, source_dir, content=None,
                            generate_from_ini=True):
         """
         Find group.xml file recursively through all module directories
         and modules. Collect data from each of them into dictionary.
 
-        @param {str} root_module_dir - directory where all modules are stored
+        @param {str} module_set_dir - directory where all modules are stored
         @param {str} source_dir - directory path for processing
         @param {str} content - module result e.g. failed,needs_action,pass,...
-        @param {int} level - indicate the depth of recursive call in directory
         @param {bool} generate_from_ini - True if xccdf-compose tool is used
 
         @return {dict} - structure is file based, keys are top level module
@@ -133,11 +132,11 @@ class ComposeXML(object):
                 directories = [x for x in os.listdir(new_dir)
                                if not os.path.isdir(os.path.join(new_dir, x))]
                 if not directories and 'postupgrade.d' not in dirname:
-                    print ("WARNING: It seems that group.ini file is missing"
-                           " in %s. Please check if it is really missing."
-                           % new_dir)
+                    print("WARNING: It seems that group.ini file is missing"
+                          " in %s. Please check if it is really missing."
+                          % new_dir)
             if ini_files and generate_from_ini:
-                oscap_group = OscapGroupXml(root_module_dir, new_dir)
+                oscap_group = OscapGroupXml(module_set_dir, new_dir)
                 oscap_group.write_xml()
                 return_list = oscap_group.collect_group_xmls()
                 ComposeXML.perform_autoqa(new_dir, return_list)
@@ -147,12 +146,12 @@ class ComposeXML(object):
                 continue
             try:
                 ret[dirname] = (ElementTree.parse(group_file_path).getroot(),
-                                ComposeXML.collect_group_xmls(root_module_dir,
-                                new_dir, level=level + 1,
-                                generate_from_ini=generate_from_ini))
+                                ComposeXML.collect_group_xmls(
+                                    module_set_dir, new_dir,
+                                    generate_from_ini=generate_from_ini))
             except ParseError as e:
-                print ("Encountered a parse error in file ", group_file_path,
-                       " details: ", e)
+                print("Encountered a parse error in file ", group_file_path,
+                      " details: ", e)
         return ret
 
     @staticmethod
@@ -375,7 +374,7 @@ class ComposeXML(object):
         if os.path.exists(os.path.join(dir_name, settings.file_list_rules)):
             os.unlink(os.path.join(dir_name, settings.file_list_rules))
         group_xmls = ComposeXML.collect_group_xmls(dir_name, dir_name, content,
-                                                   0, generate_from_ini)
+                                                   generate_from_ini)
         logger_debug.debug("Group xmls '%s'", group_xmls)
         if generate_from_ini:
             ComposeXML.perform_autoqa(dir_name, group_xmls)

--- a/preupg/xmlgen/oscap_group_xml.py
+++ b/preupg/xmlgen/oscap_group_xml.py
@@ -34,7 +34,7 @@ class OscapGroupXml(object):
     def __init__(self, module_set_dir, dir_name):
         """
         @param {str} module_set_dir - directory where all modules are stored
-        @param {str} dir_name - directory of specific module or module
+        @param {str} dir_name - directory of specific module or module-set
             directory
         """
         self.module_set_dir = module_set_dir

--- a/preupg/xmlgen/oscap_group_xml.py
+++ b/preupg/xmlgen/oscap_group_xml.py
@@ -31,7 +31,13 @@ class OscapGroupXml(object):
 
     """Class creates a XML file for OpenSCAP"""
 
-    def __init__(self, dir_name):
+    def __init__(self, root_module_dir, dir_name):
+        """
+        @param {str} root_module_dir - directory where all modules are stored
+        @param {str} dir_name - directory of specific method or method
+            directory
+        """
+        self.root_module_dir = root_module_dir
         self.dirname = dir_name
         if dir_name.endswith('/'):
             self.main_dir = dir_name.split('/')[-3]
@@ -79,7 +85,7 @@ class OscapGroupXml(object):
         """The function is used for storing a group.xml file"""
         self.find_all_ini()
         self.write_list_rules()
-        xml_utils = XmlUtils(self.dirname, self.loaded)
+        xml_utils = XmlUtils(self.root_module_dir, self.dirname, self.loaded)
         self.rule = xml_utils.prepare_sections()
         file_name = os.path.join(self.dirname, "group.xml")
         try:
@@ -92,8 +98,8 @@ class OscapGroupXml(object):
     def write_profile_xml(self, target_tree):
         """The function stores all-xccdf.xml file into content directory"""
         file_name = os.path.join(self.dirname, "all-xccdf.xml")
-        print ('File which can be used by Preupgrade-Assistant is: %s'
-               % file_name)
+        print('File which can be used by Preupgrade-Assistant is: %s'
+              % file_name)
         try:
             # encoding must be set! otherwise ElementTree return non-ascii
             # characters as html entities instead, which are unsusable for us

--- a/preupg/xmlgen/oscap_group_xml.py
+++ b/preupg/xmlgen/oscap_group_xml.py
@@ -31,13 +31,13 @@ class OscapGroupXml(object):
 
     """Class creates a XML file for OpenSCAP"""
 
-    def __init__(self, root_module_dir, dir_name):
+    def __init__(self, module_set_dir, dir_name):
         """
-        @param {str} root_module_dir - directory where all modules are stored
-        @param {str} dir_name - directory of specific method or method
+        @param {str} module_set_dir - directory where all modules are stored
+        @param {str} dir_name - directory of specific module or module
             directory
         """
-        self.root_module_dir = root_module_dir
+        self.module_set_dir = module_set_dir
         self.dirname = dir_name
         if dir_name.endswith('/'):
             self.main_dir = dir_name.split('/')[-3]
@@ -85,7 +85,7 @@ class OscapGroupXml(object):
         """The function is used for storing a group.xml file"""
         self.find_all_ini()
         self.write_list_rules()
-        xml_utils = XmlUtils(self.root_module_dir, self.dirname, self.loaded)
+        xml_utils = XmlUtils(self.module_set_dir, self.dirname, self.loaded)
         self.rule = xml_utils.prepare_sections()
         file_name = os.path.join(self.dirname, "group.xml")
         try:

--- a/preupg/xmlgen/xml_utils.py
+++ b/preupg/xmlgen/xml_utils.py
@@ -12,12 +12,12 @@ from preupg.xmlgen.script_utils import ModuleHelper
 from preupg.exception import EmptyTagGroupXMLError
 
 
-def module_path_from_root_dir(dirname, root_module_dir):
+def module_path_from_root_dir(dirname, module_set_dir):
     """
-    Remove root_module_dir from dirname path
+    Remove module_set_dir from dirname path
 
     @param {str} dir_name - directory of specific method or method directory
-    @param {str} root_module_dir - directory where all modules are stored
+    @param {str} module_set_dir - directory where all modules are stored
 
     @return {list} - splited path to module
 
@@ -27,7 +27,7 @@ def module_path_from_root_dir(dirname, root_module_dir):
     ['selinux', 'CustomPolicy']
     """
     return (dirname
-            .replace(root_module_dir, '', 1)
+            .replace(module_set_dir, '', 1)
             .lstrip(os.path.sep)  # remove first / from path
             .split(os.path.sep))
 
@@ -35,15 +35,15 @@ def module_path_from_root_dir(dirname, root_module_dir):
 class XmlUtils(object):
     """Class generate a XML from xml_tags and loaded INI file"""
 
-    def __init__(self, root_module_dir, module_dir, ini_files):
+    def __init__(self, module_set_dir, module_dir, ini_files):
         """
-        @param {str} root_module_dir - directory where all modules are stored
+        @param {str} module_set_dir - directory where all modules are stored
         @param {str} module_dir - directory of specific method or method
             directory
         @param {dict} ini_files - ini file options and their values in format:
             {ini_file_path: {option1: value, option2: value, ...}}
         """
-        self.root_module_dir = root_module_dir
+        self.module_set_dir = module_set_dir
         self.module_dir = module_dir
         self.ini_files = ini_files
 
@@ -143,7 +143,7 @@ class XmlUtils(object):
         elif search_exp == "{solution_text}":
             new_text = "_" + '_'.join(
                 module_path_from_root_dir(self.module_dir,
-                                          self.root_module_dir))\
+                                          self.module_set_dir))\
                        + "_SOLUTION_MSG_" + replace_exp.upper()
             replace_exp = new_text
         if replace_exp == '' and search_exp in forbidden_empty:
@@ -163,11 +163,11 @@ class XmlUtils(object):
             value_tag.append(xml_tags.VALUE)
             if key == 'current_directory':
                 val = '/'.join(module_path_from_root_dir(self.module_dir,
-                                                         self.root_module_dir))
+                                                         self.module_set_dir))
                 val = 'SCENARIO/' + val
             if key == 'module_path':
                 val = '_'.join(module_path_from_root_dir(self.module_dir,
-                                                         self.root_module_dir))
+                                                         self.module_set_dir))
             self.update_values_list(value_tag, "{value_name}", val)
             self.update_values_list(value_tag, "{val}", key.lower())
             check_export_tag.append(xml_tags.RULE_SECTION_VALUE)
@@ -249,7 +249,7 @@ class XmlUtils(object):
             self.update_values_list(self.rule, "{main_dir}",
                                     '_'.join(module_path_from_root_dir(
                                         self.module_dir,
-                                        self.root_module_dir)))
+                                        self.module_set_dir)))
         return self.rule
 
     def fnc_config_file(self, key, name):
@@ -301,7 +301,7 @@ class XmlUtils(object):
         content = "{rule}{main_dir}_{name}".format(
             rule=xml_tags.TAG_RULE,
             main_dir='_'.join(module_path_from_root_dir(self.module_dir,
-                                                        self.root_module_dir)),
+                                                        self.module_set_dir)),
             name=key.split('.')[0])
         if not name:
             self.update_files('migrate', content)

--- a/preupg/xmlgen/xml_utils.py
+++ b/preupg/xmlgen/xml_utils.py
@@ -16,7 +16,8 @@ def module_path_from_root_dir(dirname, module_set_dir):
     """
     Remove module_set_dir from dirname path
 
-    @param {str} dir_name - directory of specific method or method directory
+    @param {str} dir_name - directory of specific module or module-set
+        directory
     @param {str} module_set_dir - directory where all modules are stored
 
     @return {list} - splited path to module
@@ -38,7 +39,7 @@ class XmlUtils(object):
     def __init__(self, module_set_dir, module_dir, ini_files):
         """
         @param {str} module_set_dir - directory where all modules are stored
-        @param {str} module_dir - directory of specific method or method
+        @param {str} module_dir - directory of specific module or module-set
             directory
         @param {dict} ini_files - ini file options and their values in format:
             {ini_file_path: {option1: value, option2: value, ...}}

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -26,7 +26,6 @@ class TestContentGenerate(base.TestCase):
     def setUp(self):
         self.temp_dir = tempfile.mkdtemp(prefix='preupgrade', dir='/tmp')
         self.dir_name = os.path.join(os.getcwd(), 'tests', FOO_DIR)
-        print()
         self.result_dir = os.path.join(self.temp_dir, 'tests', FOO_RESULTS)
         shutil.copytree(self.dir_name, os.path.join(self.temp_dir, FOO_DIR))
         self.dir_name = os.path.join(self.temp_dir, FOO_DIR)

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -26,6 +26,7 @@ class TestContentGenerate(base.TestCase):
     def setUp(self):
         self.temp_dir = tempfile.mkdtemp(prefix='preupgrade', dir='/tmp')
         self.dir_name = os.path.join(os.getcwd(), 'tests', FOO_DIR)
+        print()
         self.result_dir = os.path.join(self.temp_dir, 'tests', FOO_RESULTS)
         shutil.copytree(self.dir_name, os.path.join(self.temp_dir, FOO_DIR))
         self.dir_name = os.path.join(self.temp_dir, FOO_DIR)
@@ -42,7 +43,8 @@ class TestContentGenerate(base.TestCase):
         for content in expected_contents:
             compose_xml = ComposeXML()
             result_dir = os.path.join(self.dir_name, content)
-            compose_xml.collect_group_xmls(self.dir_name, content=content)
+            compose_xml.collect_group_xmls(self.dir_name, self.dir_name,
+                                           content=content)
             self.assertTrue(os.path.exists(os.path.join(result_dir, 'group.xml')))
             self.assertFalse(os.path.exists(os.path.join(result_dir, 'all-xccdf.xml')))
 
@@ -69,7 +71,7 @@ class TestGlobalContent(base.TestCase):
         for content in expected_contents:
             compose_xml = ComposeXML()
             dir_name = os.path.join(self.temp_dir, FOO_DIR)
-            compose_xml.collect_group_xmls(dir_name, content=content)
+            compose_xml.collect_group_xmls(dir_name, dir_name, content=content)
 
         xccdf_compose = XCCDFCompose(os.path.join(self.temp_dir, FOO_DIR))
         xccdf_compose.generate_xml()

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -117,9 +117,8 @@ class TestScriptGenerator(base.TestCase):
     test_ini = []
 
     def setUp(self):
-        self.dirname = os.path.join("tests",
-                                    "FOOBAR6_7" + settings.results_postfix,
-                                    "test")
+        self.root_dir_name = "tests/FOOBAR6_7" + settings.results_postfix
+        self.dirname = os.path.join(self.root_dir_name, "test")
         if os.path.exists(self.dirname):
             shutil.rmtree(self.dirname)
         os.makedirs(self.dirname)
@@ -159,21 +158,24 @@ A solution text for test suite"
     def test_applies_to(self):
         self.test_ini['applies_to'] = 'test_rpm'
         self.loaded_ini[self.filename] = self.test_ini
-        self.xml_utils = XmlUtils(self.dirname, self.loaded_ini)
+        self.xml_utils = XmlUtils(self.root_dir_name, self.dirname,
+                                  self.loaded_ini)
         self.rule = self.xml_utils.prepare_sections()
         self.assertTrue(self._return_check('check_applies_to "test_rpm"'))
 
     def test_check_bin(self):
         self.test_ini['binary_req'] = 'cpf'
         self.loaded_ini[self.filename] = self.test_ini
-        self.xml_utils = XmlUtils(self.dirname, self.loaded_ini)
+        self.xml_utils = XmlUtils(self.root_dir_name, self.dirname,
+                                  self.loaded_ini)
         self.rule = self.xml_utils.prepare_sections()
         self.assertTrue(self._return_check('check_rpm_to "" "cpf"'))
 
     def test_check_rpm(self):
         self.test_ini['requires'] = 'test_rpm'
         self.loaded_ini[self.filename] = self.test_ini
-        self.xml_utils = XmlUtils(self.dirname, self.loaded_ini)
+        self.xml_utils = XmlUtils(self.root_dir_name, self.dirname,
+                                  self.loaded_ini)
         self.rule = self.xml_utils.prepare_sections()
         self.assertTrue(self._return_check('check_rpm_to "test_rpm" ""'))
 
@@ -181,7 +183,8 @@ A solution text for test suite"
         self.test_ini['binary_req'] = 'cpf'
         self.test_ini['requires'] = 'test_rpm'
         self.loaded_ini[self.filename] = self.test_ini
-        self.xml_utils = XmlUtils(self.dirname, self.loaded_ini)
+        self.xml_utils = XmlUtils(self.root_dir_name, self.dirname,
+                                  self.loaded_ini)
         self.rule = self.xml_utils.prepare_sections()
         self.assertTrue(self._return_check('check_rpm_to "test_rpm" "cpf"'))
 
@@ -189,7 +192,8 @@ A solution text for test suite"
         self.test_ini['applies_to'] = 'test_rpm'
         self.test_ini['binary_req'] = 'cpf'
         self.loaded_ini[self.filename] = self.test_ini
-        self.xml_utils = XmlUtils(self.dirname, self.loaded_ini)
+        self.xml_utils = XmlUtils(self.root_dir_name, self.dirname,
+                                  self.loaded_ini)
         self.rule = self.xml_utils.prepare_sections()
         self.assertTrue(self._return_check('check_applies_to "test_rpm"'))
         self.assertTrue(self._return_check('check_rpm_to "" "cpf"'))
@@ -212,9 +216,8 @@ class TestXML(base.TestCase):
     xml_utils = None
 
     def setUp(self):
-        self.dirname = os.path.join("tests",
-                                    "FOOBAR6_7" + settings.results_postfix,
-                                    "test")
+        self.root_dir_name = "tests/FOOBAR6_7" + settings.results_postfix
+        self.dirname = os.path.join(self.root_dir_name, "test")
         if os.path.exists(self.dirname):
             shutil.rmtree(self.dirname)
         os.makedirs(self.dirname)
@@ -249,7 +252,8 @@ A solution text for test suite"
         test_solution_name = os.path.join(self.dirname, self.test_solution)
         FileHelper.write_to_file(test_solution_name, "wb", self.solution_text)
         os.chmod(check_name, stat.S_IEXEC | stat.S_IRWXG | stat.S_IRWXU)
-        self.xml_utils = XmlUtils(self.dirname, self.loaded_ini)
+        self.xml_utils = XmlUtils(self.root_dir_name, self.dirname,
+                                  self.loaded_ini)
         self.rule = self.xml_utils.prepare_sections()
 
     def tearDown(self):
@@ -286,14 +290,16 @@ A solution text for test suite"
 
     def test_xml_solution_type_text(self):
         self.loaded_ini[self.filename]['solution_type'] = "text"
-        self.xml_utils = XmlUtils(self.dirname, self.loaded_ini)
+        self.xml_utils = XmlUtils(self.root_dir_name, self.dirname,
+                                  self.loaded_ini)
         self.rule = self.xml_utils.prepare_sections()
         fix_text = [x for x in self.rule if "<fixtext>_test_SOLUTION_MSG_TEXT</fixtext>" in x]
         self.assertTrue(fix_text)
 
     def test_xml_solution_type_html(self):
         self.loaded_ini[self.filename]['solution_type'] = "html"
-        self.xml_utils = XmlUtils(self.dirname, self.loaded_ini)
+        self.xml_utils = XmlUtils(self.root_dir_name, self.dirname,
+                                  self.loaded_ini)
         self.rule = self.xml_utils.prepare_sections()
         fix_text = [x for x in self.rule if "<fixtext>_test_SOLUTION_MSG_HTML</fixtext>" in x]
         self.assertTrue(fix_text)
@@ -347,7 +353,7 @@ A solution text for test suite"
         old_settings = settings.UPGRADE_PATH
         migrate, upgrade = self._create_temporary_dir()
         ini[self.filename] = test_ini
-        xml_utils = XmlUtils(self.dirname, ini)
+        xml_utils = XmlUtils(self.root_dir_name, self.dirname, ini)
         xml_utils.prepare_sections()
         migrate_file = FileHelper.get_file_content(migrate, 'rb', method=True)
         tag = [x.strip() for x in migrate_file if 'xccdf_preupg_rule_test_check_script' in x.strip()]
@@ -375,7 +381,7 @@ A solution text for test suite"
         old_settings = settings.UPGRADE_PATH
         migrate, upgrade = self._create_temporary_dir()
         ini[self.filename] = test_ini
-        xml_utils = XmlUtils(self.dirname, ini)
+        xml_utils = XmlUtils(self.root_dir_name, self.dirname, ini)
         xml_utils.prepare_sections()
         upgrade_file = FileHelper.get_file_content(upgrade, 'rb', method=True)
         tag = [x.strip() for x in upgrade_file if 'xccdf_preupg_rule_test_check_script' in x.strip()]
@@ -403,7 +409,7 @@ A solution text for test suite"
         old_settings = settings.UPGRADE_PATH
         migrate, upgrade = self._create_temporary_dir()
         ini[self.filename] = test_ini
-        xml_utils = XmlUtils(self.dirname, ini)
+        xml_utils = XmlUtils(self.root_dir_name, self.dirname, ini)
         xml_utils.prepare_sections()
         migrate_file = FileHelper.get_file_content(migrate, 'rb', method=True)
         tag = [x.strip() for x in migrate_file if 'xccdf_preupg_rule_test_check_script' in x.strip()]
@@ -428,7 +434,7 @@ A solution text for test suite"
         old_settings = settings.UPGRADE_PATH
         migrate, upgrade = self._create_temporary_dir()
         ini[self.filename] = test_ini
-        xml_utils = XmlUtils(self.dirname, ini)
+        xml_utils = XmlUtils(self.root_dir_name, self.dirname, ini)
         xml_utils.prepare_sections()
         migrate_file = FileHelper.get_file_content(migrate, 'rb', method=True)
         tag = [x.strip() for x in migrate_file if 'xccdf_preupg_rule_test_check_script' in x.strip()]
@@ -486,7 +492,8 @@ class TestIncorrectINI(base.TestCase):
     xml_utils = None
 
     def setUp(self):
-        self.dir_name = "tests/FOOBAR6_7/incorrect_ini"
+        self.root_dir_name = "tests/FOOBAR6_7"
+        self.dir_name = os.path.join(self.root_dir_name, "incorrect_ini")
         os.makedirs(self.dir_name)
         self.filename = os.path.join(self.dir_name, 'test.ini')
         self.rule = []
@@ -519,28 +526,32 @@ A solution text for test suite"
         """Basic test for whole program"""
         self.test_ini.pop('check_script', None)
         self.loaded_ini[self.filename] = self.test_ini
-        self.xml_utils = XmlUtils(self.dir_name, self.loaded_ini)
+        self.xml_utils = XmlUtils(self.root_dir_name, self.dir_name,
+                                  self.loaded_ini)
         self.assertRaises(MissingTagsIniFileError, lambda: list(self.xml_utils.prepare_sections()))
 
     def test_missing_tag_solution_script(self):
         """Test of missing tag 'solution' - MissingTagsIniFileError should be raised"""
         self.test_ini.pop('solution', None)
         self.loaded_ini[self.filename] = self.test_ini
-        self.xml_utils = XmlUtils(self.dir_name, self.loaded_ini)
+        self.xml_utils = XmlUtils(self.root_dir_name, self.dir_name,
+                                  self.loaded_ini)
         self.assertRaises(MissingTagsIniFileError, lambda: list(self.xml_utils.prepare_sections()))
 
     def test_file_solution_not_exists(self):
         """Test of missing 'solution' file - IOError should be raised"""
         self.test_ini['solution'] = "this_should_be_unexpected_file.txt"
         self.loaded_ini[self.filename] = self.test_ini
-        self.xml_utils = XmlUtils(self.dir_name, self.loaded_ini)
+        self.xml_utils = XmlUtils(self.root_dir_name, self.dir_name,
+                                  self.loaded_ini)
         self.assertRaises(IOError, lambda: list(self.xml_utils.prepare_sections()))
 
     def test_file_check_script_not_exists(self):
         """Test of missing 'check_script' file"""
         self.test_ini['check_script'] = "this_should_be_unexpected_file.txt"
         self.loaded_ini[self.filename] = self.test_ini
-        self.xml_utils = XmlUtils(self.dir_name, self.loaded_ini)
+        self.xml_utils = XmlUtils(self.root_dir_name, self.dir_name,
+                                  self.loaded_ini)
         self.assertRaises(MissingFileInContentError, lambda: list(self.xml_utils.prepare_sections()))
 
     def test_check_script_is_directory(self):
@@ -550,8 +561,8 @@ A solution text for test suite"
         """
         self.test_ini['check_script'] = '.'
         self.loaded_ini[self.filename] = self.test_ini
-        print(self.loaded_ini)
-        self.xml_utils = XmlUtils(self.dir_name, self.loaded_ini)
+        self.xml_utils = XmlUtils(self.root_dir_name, self.dir_name,
+                                  self.loaded_ini)
         self.assertRaises(IOError, lambda: list(self.xml_utils.prepare_sections()))
 
     def test_incorrect_tag(self):
@@ -563,7 +574,7 @@ A solution text for test suite"
         text_ini += '\n'.join([key + " = " + self.test_ini[key] for key in self.test_ini])
         text_ini += '\n[]\neliskk\n'
         FileHelper.write_to_file(self.filename, "wb", text_ini)
-        oscap = OscapGroupXml(self.dir_name)
+        oscap = OscapGroupXml(self.root_dir_name, self.dir_name)
         self.assertRaises(configparser.ParsingError, oscap.find_all_ini)
 
     def test_secret_check_script(self):
@@ -572,7 +583,8 @@ A solution text for test suite"
         text = """#!/usr/bin/sh\necho 'ahojky'\n"""
         FileHelper.write_to_file(os.path.join(self.dir_name, self.check_script), "wb", text)
         self.loaded_ini[self.filename] = self.test_ini
-        self.xml_utils = XmlUtils(self.dir_name, self.loaded_ini)
+        self.xml_utils = XmlUtils(self.root_dir_name, self.dir_name,
+                                  self.loaded_ini)
         self.assertRaises(MissingFileInContentError, lambda: list(self.xml_utils.prepare_sections()))
 
 
@@ -587,7 +599,8 @@ class TestGroupXML(base.TestCase):
     xml_utils = None
 
     def setUp(self):
-        self.dir_name = "tests/FOOBAR6_7-results/test_group"
+        self.root_dir_name = "tests/FOOBAR6_7"
+        self.dir_name = os.path.join(self.root_dir_name, "test_group")
         os.makedirs(self.dir_name)
         self.filename = os.path.join(self.dir_name, 'group.ini')
         test_ini = {'group_title': 'Testing content title'}
@@ -599,7 +612,8 @@ class TestGroupXML(base.TestCase):
 
     def test_group_ini(self):
         """Basic test creation group.xml file"""
-        self.xml_utils = XmlUtils(self.dir_name, self.loaded_ini)
+        self.xml_utils = XmlUtils(self.root_dir_name, self.dir_name,
+                                  self.loaded_ini)
         self.rule = self.xml_utils.prepare_sections()
         group_tag = [x for x in self.rule if '<Group id="xccdf_preupg_group_test_group" selected="true">' in x]
         self.assertTrue(group_tag)


### PR DESCRIPTION
When run:
```
preupg-xccdf-compose RHEL6_7
```
tag generated in group.xml looks like:
```xml
<value>SCENARIO/backup/bacula</value>  
```
but when run:
```
preupg-xccdf-compose moduleDir
```
tag looks like:
```xml
<value>SCENARIO/root/moduleDir-results/backup/bacula</value>
```
This concerns multiple tags through xml files not only one showed above.