### PR TITLE
Fix getting right module set directory

### DIFF
--- a/preupg/application.py
+++ b/preupg/application.py
@@ -298,6 +298,7 @@ class Application(object):
         try:
             sep_content = os.path.dirname(self.content).split('/')
             if self.conf.contents:
+                # remove all-xccdf.xml from path and get last directory
                 dir_name = ModuleSetUtils.get_module_set_dirname(self.content)
                 if dir_name is None:
                     return None

--- a/preupg/creator/settings.py
+++ b/preupg/creator/settings.py
@@ -41,6 +41,8 @@ summary_solution = '- the solution text which informs about incompatibilities %s
 check_path = "The %s file already exists. Do you want to replace the file?"
 type_check_script = "Would you like to create a BASH or Python check script? [sh/py] Bash is default."
 properties_ini = "- Fill empty options in %s before you use it."
+prop_src_version = "Specify major source OS version e.g. \"6\":"
+prop_dst_version = "Specify major destination OS version e.g. \"7\":"
 
 text_for_testing = "\nFor testing content run these two commands:\n" \
                    "- preupg-create-group-xml %s to create XML file\n" \

--- a/preupg/creator/settings.py
+++ b/preupg/creator/settings.py
@@ -40,6 +40,7 @@ summary_check = '- the check script which provides an assessment is %s. Update i
 summary_solution = '- the solution text which informs about incompatilibies is %s. Update it before you use it.'
 check_path = "The %s file already exists. Do you want to replace the file?"
 type_check_script = "Would you like to create a BASH or Python check script? [sh/py] Bash is default."
+properties_ini = "Fill empty options in %s before you use it."
 
 text_for_testing = "\nFor testing content run these two commands:\n" \
                    "- preupg-create-group-xml %s to create XML file\n" \

--- a/preupg/creator/settings.py
+++ b/preupg/creator/settings.py
@@ -37,10 +37,10 @@ summary_title = 'preupg-content-creator generated these files to be updated:'
 summary_directory = '- the module was created in the %s directory.'
 summary_ini = '- the INI file which defines the module is %s.'
 summary_check = '- the check script which provides an assessment is %s. Update it before you use it.'
-summary_solution = '- the solution text which informs about incompatilibies is %s. Update it before you use it.'
+summary_solution = '- the solution text which informs about incompatibilities %s. Update it before you use it.'
 check_path = "The %s file already exists. Do you want to replace the file?"
 type_check_script = "Would you like to create a BASH or Python check script? [sh/py] Bash is default."
-properties_ini = "Fill empty options in %s before you use it."
+properties_ini = "- Fill empty options in %s before you use it."
 
 text_for_testing = "\nFor testing content run these two commands:\n" \
                    "- preupg-create-group-xml %s to create XML file\n" \

--- a/preupg/creator/ui_helper.py
+++ b/preupg/creator/ui_helper.py
@@ -12,11 +12,9 @@ import sys
 from distutils.util import strtobool
 from preupg.utils import FileHelper, ModuleSetUtils
 from preupg.creator import settings
+from preupg import settings as preupgSettings
 
 from preupg.settings import content_file as ALL_XCCDF_XML
-
-section = 'preupgrade'
-PROPERTIES_FILE_NAME = 'properties.ini'
 
 
 def get_user_input(message, default_yes=True, any_input=False):
@@ -129,13 +127,15 @@ class UIHelper(object):
         self.content_path = os.path.join(self.get_group_name(),
                                          self.get_content_name())
 
-    def properties_ini(self):
-        """ If properties.ini file doesnt exist ask user for OS versions """
+    def ask_about_properties_ini(self):
+        """ If properties.ini file doesnt exist ask user for OS versions,
+        otherwise don't ask anything
+        """
         self.properties_ini_path = os.path.join(
             self.get_upgrade_path(),
-            PROPERTIES_FILE_NAME)
+            preupgSettings.properties_ini)
         if not self.properties_ini_exists():
-            self.get_properties_ini_versions()  # ask user for versions
+            self.get_properties_ini_versions()  # ask user forn  versions
 
     def properties_ini_exists(self):
         if self.properties_ini_path:
@@ -229,10 +229,10 @@ class UIHelper(object):
         :return:
         """
         config = ConfigParser.RawConfigParser()
-        config.add_section(section)
+        config.add_section(preupgSettings.prefix)
         for key, val in iter(self.content_dict.items()):
             if val is not None:
-                config.set(section, key, val)
+                config.set(preupgSettings.prefix, key, val)
 
         self.content_ini = self.get_content_name() + '.ini'
         ini_path = os.path.join(self.get_content_path(), self.get_content_ini_file())
@@ -264,8 +264,8 @@ class UIHelper(object):
         :return:
         """
         config = ConfigParser.RawConfigParser()
-        config.add_section(section)
-        config.set(section, 'group_title', 'Title for %s ' % self.get_group_name())
+        config.add_section(preupgSettings.prefix)
+        config.set(preupgSettings.prefix, 'group_title', 'Title for %s ' % self.get_group_name())
 
         file_name = 'group.ini'
         group_ini = os.path.join(self.get_upgrade_path(),
@@ -328,7 +328,7 @@ class UIHelper(object):
             if self.specify_upgrade_path() is None:
                 return 1
 
-            self.properties_ini()
+            self.ask_about_properties_ini()
 
             self.get_content_info()
             if self.refresh_content:

--- a/preupg/creator/ui_helper.py
+++ b/preupg/creator/ui_helper.py
@@ -127,7 +127,7 @@ class UIHelper(object):
         self.content_path = os.path.join(self.get_group_name(),
                                          self.get_content_name())
 
-    def ask_about_properties_ini(self):
+    def get_properties_ini_info(self):
         """ If properties.ini file doesnt exist ask user for OS versions,
         otherwise don't ask anything
         """
@@ -135,14 +135,14 @@ class UIHelper(object):
             self.get_upgrade_path(),
             preupgSettings.properties_ini)
         if not self.properties_ini_exists():
-            self.get_properties_ini_versions()  # ask user forn  versions
+            self.ask_for_properties_ini_versions()
 
     def properties_ini_exists(self):
         if self.properties_ini_path:
             return os.path.isfile(self.properties_ini_path)
         return False
 
-    def get_properties_ini_versions(self):
+    def ask_for_properties_ini_versions(self):
         """
         Asks user for src,dst OS versions, while options are mandatory user
         input is required
@@ -328,7 +328,7 @@ class UIHelper(object):
             if self.specify_upgrade_path() is None:
                 return 1
 
-            self.ask_about_properties_ini()
+            self.get_properties_ini_info()
 
             self.get_content_info()
             if self.refresh_content:

--- a/preupg/creator/ui_helper.py
+++ b/preupg/creator/ui_helper.py
@@ -200,11 +200,10 @@ class UIHelper(object):
         @throws {IOError}
         """
         try:
-            f = open(file_path, 'wb')
-            config.write(f)
-            f.close()
+            with open(file_path, 'wb') as f:
+                config.write(f)
         except IOError:
-            print('We have a problem with writing {0} file to disc'.format(
+            print('An error occured while writing to the {0} file!'.format(
                 file_path))
             raise
 
@@ -272,16 +271,16 @@ class UIHelper(object):
         Create properties.ini inside module set directory in format:
 
         [preupgrade-assistant-modules]
-        srcMajorVersion =
-        dstMajorVersion =
+        src_major_version =
+        dst_major_version =
         """
         file_name = 'properties.ini'
         section = 'preupgrade-assistant-modules'
 
         config = ConfigParser.RawConfigParser()
         config.add_section(section)
-        config.set(section, 'srcMajorVersion', '')
-        config.set(section, 'dstMajorVersion', '')
+        config.set(section, 'src_major_version', '')
+        config.set(section, 'dst_major_version', '')
 
         self.properties_ini_path = os.path.join(self.get_upgrade_path(), file_name)
         if os.path.exists(self.properties_ini_path):

--- a/preupg/utils.py
+++ b/preupg/utils.py
@@ -880,8 +880,7 @@ class ModuleSetUtils(object):
         validate the file content. From the content gets src/dst version of OS
         and return them as list.
 
-        @param {string} dir_name - eg. /root/preupgrage/modul_dir
-        @param {string} base_dir
+        @param {string} module_set_path - eg. /root/preupgrage/modul_dir
         @return {list}
         @throws {EnvironmentError} - when file doesn't exist or content is
                                      incorrect

--- a/preupg/xmlgen/compose.py
+++ b/preupg/xmlgen/compose.py
@@ -48,8 +48,10 @@ class XCCDFCompose(object):
             shutil.rmtree(self.dir_name)
 
     def generate_xml(self, generate_from_ini=True):
-        if ModuleSetUtils.get_module_set_dirname(self.dir_name) is None:
-            sys.stderr.write('Use scenario with valid name, e.g. RHEL6_7\n')
+        try:
+            ModuleSetUtils.get_module_set_os_versions(self.result_dir)
+        except EnvironmentError as err:
+            sys.stderr.write("{0}\n".format(str(err)))
             return ReturnValues.SCENARIO
 
         dir_util.copy_tree(self.result_dir, self.dir_name)


### PR DESCRIPTION
Based on #286. 

Preupgrade-content-creator was looking for a specific upgrade path,
replace this behavior with no dependency on directory name and also add
properties.ini into new created module set directory.

In compose.py check for existing properties.ini file in exitsting
module set directory instead of in directory with '-results' postfix.