### PR TITLE
Change properties ini options to snake_case

### DIFF
--- a/doc/module_writing_tutorial/README.md
+++ b/doc/module_writing_tutorial/README.md
@@ -8,10 +8,10 @@
 3. Create a _properties.ini_ file in the _<MODULE_SET_DIR>_ directory with the following content:
 ```
 [preupgrade-assistant-modules]
-srcMajorVersion=6
-dstMajorVersion=7
+src_major_version=6
+dst_major_version=7
 ```  
->  Note: srcMajorVersion is the major version of the current system and dstMajorVersion is the major version to which the system is to be upgraded.
+>  Note: src_major_version is the major version of the current system and dst_major_version is the major version to which the system is to be upgraded.
 
 4. Make sure you have installed the _preupgrade-assistant-tools_ package, and run the _preupg-xccdf-compose_ tool as follows:
 

--- a/preupg/utils.py
+++ b/preupg/utils.py
@@ -886,8 +886,8 @@ class ModuleSetUtils(object):
         @throws {EnvironmentError} - when file doesn't exist or content is
                                      incorrect
         """
-        src_version_key = "srcMajorVersion"
-        dst_version_key = "dstMajorVersion"
+        src_version_key = "src_major_version"
+        dst_version_key = "dst_major_version"
         section_name = "preupgrade-assistant-modules"
         if not os.path.isdir(module_set_path):
             module_set_path = os.path.join(settings.source_dir,

--- a/tests/FOOBAR6_7/properties.ini
+++ b/tests/FOOBAR6_7/properties.ini
@@ -1,3 +1,3 @@
 [preupgrade-assistant-modules]
-srcMajorVersion=6
-dstMajorVersion=7
+src_major_version=6
+dst_major_version=7

--- a/tests/test_preupg.py
+++ b/tests/test_preupg.py
@@ -356,8 +356,8 @@ class TestModuleSetConfigContent(base.TestCase):
     '''
     def __init__(self, *args, **kwargs):
         super(TestModuleSetConfigContent, self).__init__(*args, **kwargs)
-        self.src_version_key = "srcMajorVersion"
-        self.dst_version_key = "dstMajorVersion"
+        self.src_version_key = "src_major_version"
+        self.dst_version_key = "dst_major_version"
         self.section_name = "preupgrade-assistant-modules"
         self.this_file_dir_path = os.path.dirname(os.path.realpath(__file__))
         self.dummy_config_path = os.path.join(self.this_file_dir_path,


### PR DESCRIPTION
Python ConfigParser module's default implementation uses lower case. So for
better readability and to prevent any misunderstandings change from
lowerCammelCase to snake_case.