### PR TITLE
Remove symbols from python and bash APIs

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -159,11 +159,6 @@ RESULT_PASS=$XCCDF_RESULT_PASS
 RESULT_FAIL=$XCCDF_RESULT_FAIL
 
 #
-# Exit status for 'fail' result
-#
-RESULT_FAILED=$RESULT_FAIL
-
-#
 # Exit status for 'error' result
 #
 RESULT_ERROR=$XCCDF_RESULT_ERROR
@@ -446,16 +441,6 @@ check_rpm_to() {
     fi
 }
 
-check_root() {
-    #
-    # This check can be used if you need root privilegues
-    #
-    if [ "$(id -u)" != "0" ]; then
-        log_error "This script must be run as root"
-        log_slight_risk "The script must be run as root"
-        exit_error
-    fi
-}
 
 solution_file() {
     #

--- a/man/preupgrade-assistant-api.1
+++ b/man/preupgrade-assistant-api.1
@@ -12,8 +12,6 @@ API provides a set of functions which can be used for better handling of your da
 
 \fBcheck_applies_to\fP - The function can be used to detect a specific RPM package. If the RPM package does not exist, check the script exit with the \fBexit_not_applicable\fP return code.
 
-\fBcheck_root\fP - The function checks whether the user is root.
-
 \fBsolution_file\fP - The function adds a message to the solution file defined in the INI file.
 
 \fBbackup_config_file\fP - The function backs up a config file to the \fB/root/preupgrade\fP directory.

--- a/preupg/script_api.py
+++ b/preupg/script_api.py
@@ -48,7 +48,6 @@ __all__ = (
 
     'exit_error',
     'exit_fail',
-    'exit_failed',
     'exit_fixed',
     'exit_informational',
     'exit_not_applicable',
@@ -416,15 +415,6 @@ def shorten_envs():
 def exit_fail():
     """
     The test failed.
-    Moving to new release with this configuration will result in malfunction.
-    """
-    sys.exit(int(os.environ['XCCDF_RESULT_FAIL']))
-
-
-def exit_failed():
-    """
-    The test failed.
-
     Moving to new release with this configuration will result in malfunction.
     """
     sys.exit(int(os.environ['XCCDF_RESULT_FAIL']))


### PR DESCRIPTION
- remove _RESULT_FAILED_ and _check_root()_ from bash API
  - _check_root_ is not needed as the Preupgrade Assistant is always run as root
  - _RESULT_FAILED_ is not present in Python and the existing _RESULT_FAIL_ is sufficient
- remove _exit_failed()_ from python API
  - the _exit_failed()_ is not in bash API and the existing _exit_fail()_ is sufficient

This resolves #199 and resolves #164