### PR TITLE
Remove get_module_set_dirname, fix list_rules and --contents

### DIFF
--- a/preupg/application.py
+++ b/preupg/application.py
@@ -455,7 +455,7 @@ class Application(object):
                 module_set_path = os.path.dirname(self.conf.contents)
                 if not os.path.isdir(module_set_path):
                     module_set_path = os.path.normpath(
-                        os.path.join(self.script_path, module_set_path))
+                        os.path.join(self.execution_dir, module_set_path))
             ModuleSetUtils.get_module_set_os_versions(module_set_path)
         except EnvironmentError as err:
             log_message(str(err), level=logging.ERROR)
@@ -762,7 +762,7 @@ class Application(object):
                             % settings.openscap_binary)
                 return ReturnValues.MISSING_OPENSCAP
 
-            self.script_path = os.getcwd()
+            self.execution_dir = os.getcwd()
             os.chdir("/tmp")
             retval = self.scan_system()
             if int(retval) != 0:
@@ -774,7 +774,7 @@ class Application(object):
             if self.conf.upload:
                 if not self.upload_results():
                     retval = ReturnValues.SEND_REPORT_TO_UI
-            os.chdir(self.script_path)
+            os.chdir(self.execution_dir)
             return retval
 
         log_message('Nothing to do. Give me a task, please.')

--- a/preupg/application.py
+++ b/preupg/application.py
@@ -453,6 +453,9 @@ class Application(object):
             if module_set_path is None:
                 # strip all-xccdf.xml from path
                 module_set_path = os.path.dirname(self.conf.contents)
+                if not os.path.isdir(module_set_path):
+                    module_set_path = os.path.normpath(
+                        os.path.join(self.script_path, module_set_path))
             ModuleSetUtils.get_module_set_os_versions(module_set_path)
         except EnvironmentError as err:
             log_message(str(err), level=logging.ERROR)
@@ -759,7 +762,7 @@ class Application(object):
                             % settings.openscap_binary)
                 return ReturnValues.MISSING_OPENSCAP
 
-            current_dir = os.getcwd()
+            self.script_path = os.getcwd()
             os.chdir("/tmp")
             retval = self.scan_system()
             if int(retval) != 0:
@@ -771,7 +774,7 @@ class Application(object):
             if self.conf.upload:
                 if not self.upload_results():
                     retval = ReturnValues.SEND_REPORT_TO_UI
-            os.chdir(current_dir)
+            os.chdir(self.script_path)
             return retval
 
         log_message('Nothing to do. Give me a task, please.')

--- a/preupg/application.py
+++ b/preupg/application.py
@@ -301,7 +301,7 @@ class Application(object):
             sep_content = os.path.dirname(self.content).split('/')
             if self.conf.contents:
                 # remove all-xccdf.xml from path and get last directory
-                dir_name = ModuleSetUtils.get_module_set_dirname(self.content)
+                dir_name = os.path.basename(os.path.dirname(self.content))
                 if dir_name is None:
                     return None
                 check_name = dir_name
@@ -525,7 +525,8 @@ class Application(object):
             return ReturnValues.SCENARIO
         if not self.conf.contents:
             try:
-                version = ModuleSetUtils.get_module_set_os_versions(self.conf.scan)
+                version = ModuleSetUtils.get_module_set_os_versions(
+                    self.conf.scan)
             except EnvironmentError as err:
                 log_message(str(err), level=logging.ERROR)
                 return ReturnValues.SCENARIO

--- a/preupg/utils.py
+++ b/preupg/utils.py
@@ -908,16 +908,3 @@ class ModuleSetUtils(object):
                                                          dst_version_key,
                                                          section_name)
         return [src_os_ver, dst_os_ver]
-
-    @staticmethod
-    def get_module_set_dirname(module_path):
-        """
-        >>> get_module_set_dirname('/dir1/dir2/file.xml')
-        'dir2'
-        >>> get_module_set_dirname('/dir1/dir2/dir3/')
-        'dir3'
-        >>> get_module_set_dirname('/dir1/dir2/dir3')
-        'dir2'
-        # doesn't check directory at the end of path, is considered as a file
-        """
-        return os.path.basename(os.path.dirname(module_path))

--- a/preupg/xmlgen/oscap_group_xml.py
+++ b/preupg/xmlgen/oscap_group_xml.py
@@ -110,9 +110,8 @@ class OscapGroupXml(object):
                           % (file_name, ioe.message))
 
     def write_list_rules(self):
-        end_point = self.dirname.find(
-            ModuleSetUtils.get_module_set_dirname(self.dirname))
-        rule_name = '_'.join(self.dirname[end_point:].split('/')[1:])
+        module_path = self.dirname.replace(self.module_set_dir, '')
+        rule_name = '_'.join(module_path.split(os.sep)[1:])
         file_list_rules = os.path.join(settings.UPGRADE_PATH,
                                        settings.file_list_rules)
         lines = []

--- a/tests/test_preupg.py
+++ b/tests/test_preupg.py
@@ -295,38 +295,6 @@ class TestModuleSet(base.TestCase):
         self.assertEqual(app.get_scenario(), 'Modules')
 
 
-class TestModuleSetDirname(base.TestCase):
-    '''
-    Test get_module_set_dirname method
-    '''
-    def test_file_ending_path(self):
-        '''
-        Test to get directory where file is located
-        '''
-        self.assertEqual(
-            ModuleSetUtils.get_module_set_dirname('/dir1/dir2/file.xml'),
-            'dir2'
-        )
-
-    def test_dir_ending_path(self):
-        '''
-        Test when file is not specified get last directory in path
-        '''
-        self.assertEqual(
-            ModuleSetUtils.get_module_set_dirname('/dir1/dir2/dir3/'),
-            'dir3'
-        )
-
-    def test_dir_as_file_ending_path(self):
-        '''
-        Test should get a second directory from the end
-        '''
-        self.assertEqual(
-            ModuleSetUtils.get_module_set_dirname('/dir1/dir2/dir3'),
-            'dir2'
-        )
-
-
 class TestModuleSetConfigParse(base.TestCase):
     '''
     Test parser of source and destination major versions of system from module
@@ -407,7 +375,6 @@ def suite():
     suite.addTest(loader.loadTestsFromTestCase(TestSolutionReplacement))
     suite.addTest(loader.loadTestsFromTestCase(TestXMLUpdates))
     suite.addTest(loader.loadTestsFromTestCase(TestModuleSet))
-    suite.addTest(loader.loadTestsFromTestCase(TestModuleSetDirname))
     suite.addTest(loader.loadTestsFromTestCase(TestModuleSetConfigParse))
     suite.addTest(loader.loadTestsFromTestCase(TestModuleSetConfigContent))
     return suite


### PR DESCRIPTION
- Remove get_module_set_dirname method from PA.
- Fix generating list_rules file: rules have wrong names e.g.:
from: `xccdf_preupg_rule_general_check` 
fixed to : `xccdf_preupg_rule_selinux_general_check`
- Fix --contents option: when option is used PA fails on finding `properties.ini` because wrong path. Use normpath in order to do the check.
