### PR TITLE
Remove properties ini msg in content-creator

### DIFF
--- a/preupg/creator/settings.py
+++ b/preupg/creator/settings.py
@@ -40,7 +40,6 @@ summary_check = '- the check script which provides an assessment is %s. Update i
 summary_solution = '- the solution text which informs about incompatibilities %s. Update it before you use it.'
 check_path = "The %s file already exists. Do you want to replace the file?"
 type_check_script = "Would you like to create a BASH or Python check script? [sh/py] Bash is default."
-properties_ini = "- Fill empty options in %s before you use it."
 prop_src_version = "Specify major source OS version e.g. \"6\":"
 prop_dst_version = "Specify major destination OS version e.g. \"7\":"
 

--- a/preupg/creator/ui_helper.py
+++ b/preupg/creator/ui_helper.py
@@ -312,7 +312,6 @@ class UIHelper(object):
                                            self.get_content_name())
         print(settings.summary_title)
         print(settings.summary_directory % self.get_content_path())
-        print(settings.properties_ini % (self.properties_ini_path))
         print(settings.summary_ini % os.path.join(content_path,
                                                   self.get_content_ini_file()))
         print(settings.summary_check % os.path.join(content_path,


### PR DESCRIPTION
Message is obsolete because content-creator itself is taking care of
options in properties.ini.