### PR TITLE
Fix links to files & dirs in Web UI reports

### DIFF
--- a/preupg/ui/report/processing.py
+++ b/preupg/ui/report/processing.py
@@ -72,7 +72,7 @@ def set_if_true(d, key, value):
         d[key] = value
 
 
-class ReportParser(object):
+class XMLReportParser(object):
 
     def __init__(self, report_path):
         """
@@ -286,17 +286,26 @@ class ReportParser(object):
         return self.run
 
 
-def parse_report(file_path):
-    """ parse XML report """
-    r = ReportParser(file_path)
+def parse_xml_report(xml_filepath):
+    r = XMLReportParser(xml_filepath)
     return r.parse_report()
+
+
+def update_html_report(html_filepath):
+    """Links to files and folders need to be updated to work in the Web UI."""
+    with open(html_filepath, 'r') as infile:
+        updated_html = re.sub(r'<a href="(./|file:)([^"]+)"\s*>',
+                              r'<a href="../file/?path=\2" target="_blank">',
+                              infile.read())
+    with open(html_filepath, 'w') as outfile:
+        outfile.write(updated_html)
 
 
 def main():
     from pprint import pprint
     import sys
     try:
-        r = parse_report(sys.argv[1])
+        r = parse_xml_report(sys.argv[1])
     except KeyError:
         print ('Usage: prog <content.xml>')
         sys.exit(1)

--- a/preupg/ui/report/service.py
+++ b/preupg/ui/report/service.py
@@ -9,7 +9,7 @@ import shutil
 from .models import Test, TestResult, HostRun, Result, Address, TestLog, TestGroup, TestGroupResult
 from .models import Risk
 
-from processing import parse_report
+from processing import parse_xml_report, update_html_report
 
 from django.db import transaction
 from django.conf import settings
@@ -49,8 +49,8 @@ def extract_tarball(tbpath, target_dir):
         content.
         """
         for member in tar_content:
-            path_wo_subfolder = member.path.split(os.sep)[1:]
-            if path_wo_subfolder:
+            path_without_subfolder = member.path.split(os.sep)[1:]
+            if path_without_subfolder:
                 member.path = os.path.join(*member.path.split(os.sep)[1:])
                 yield member
 
@@ -112,7 +112,8 @@ class ReportImporter(object):
         xml_path, html_path = extract_tarball(self.tb_path, self.result.get_result_dir())
         self.html_path = html_path
         remove_upload(self.tb_path)
-        return parse_report(xml_path)
+        update_html_report(self.html_path)
+        return parse_xml_report(xml_path)
 
     @transaction.commit_on_success
     def _add_to_db(self):

--- a/preupg/ui/report/tests.py
+++ b/preupg/ui/report/tests.py
@@ -3,13 +3,13 @@
 import shutil
 import unittest
 import tempfile
-import preup
+import preupg
 
 from xml.etree import ElementTree
 from preupg.application import Application
 from preupg.conf import DummyConf, Conf
-from report.processing import xml_to_html, stringify_children, parse_report
-from report.service import extract_tarball
+from preupg.ui.report.processing import xml_to_html, stringify_children, parse_xml_report
+from preupg.ui.report.service import extract_tarball
 
 from django.test import TestCase
 
@@ -82,7 +82,7 @@ Text outside tag <html:div>Text <html:em>inside</html:em> tag</html:div> x <b>y<
 #         tarball_path = a.scan_system()
 #
 #         xml_path, html_path = extract_tarball(tarball_path, self.temp_dir)
-#         self.assertTrue(len(parse_report(xml_path)) > 0)
+#         self.assertTrue(len(parse_xml_report(xml_path)) > 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Any link to a file or folder in the Web UI did not work. There were three problems:
- During the upload to the UI, the tarball with the system assessment results was extracted. However, all content in the tarball is under the _preupg_results-\<timestamp\>_ subfolder - the Web UI does not expect this subfolder. Now, just the content that is under this subfolder is extracted.
- Previously, it was possible to display only files (to which there was a link in the Web UI report), not folders. Now, if the user clicks on a link to a folder, the Web UI displays the content of the folder.
- It was possible to view **the original** HTML report through Web UI. Within the report there might be links to files & folders that work correctly in its default location (_/root/preupgrade_) but not in the Web UI. For that, these links need to be updated in the report right after extracting the tarball on the Web UI server.

Resolves [rhbz#1473515](https://bugzilla.redhat.com/show_bug.cgi?id=1473515)