### PR TITLE
Fix Landscape health icon

### DIFF
--- a/.landscape.yaml
+++ b/.landscape.yaml
@@ -1,17 +1,14 @@
-# Include warnings about missing documentation?
-doc-warnings: True
-
-# Include warnings about tests?
+# Include code analysis of unit tests?
 test-warnings: False
 
-# tests stricktness
+# Code analysis stricktness
 strictness: medium
 max-line-length: 120
 
-# autodetect dependencies?
+# Autodetect dependencies?
 autodetect: True
 
-# paths to be ignored
+# Paths to be ignored
 ignore-paths:
     - docs
     - preupg/ui
@@ -19,3 +16,6 @@ ignore-paths:
     - tests
 ignore-patterns:
     - ^preupg/script_api.py$
+
+python-targets:
+    - 2

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The Preupgrade Assistant
 
-[![Code Health](https://landscape.io/github/phracek/preupgrade-assistant/master/landscape.svg?style=flat)](https://landscape.io/github/phracek/preupgrade-assistant/master) ![Jenkins CI build status](https://preupg.000webhostapp.com/master.svg)
+[![Code Health](https://landscape.io/github/upgrades-migrations/preupgrade-assistant/master/landscape.svg?style=flat)](https://landscape.io/github/upgrades-migrations/preupgrade-assistant/master) ![Jenkins CI build status](https://preupg.000webhostapp.com/master.svg)
 
 The Preupgrade Assistant is a diagnostics utility that assesses the system for possible in-place upgrade limitations and provides a report with the analysis results. It is based on a module system, with each module performing a separate test, checking for package removals, incompatible obsoletes, changes in libraries, name changes, or deficiencies in the compatibilities of certain configuration files. The data gathered by the Preupgrade Assistant can be used for cloning the system. It also provides post-upgrade scripts to finish more complex problems after the in-place upgrade. The Preupgrade Assistant utility is a prerequisite for completing a successful in-place upgrade to the next major version of Red Hat Enterprise Linux. The data gathered by the Preupgrade Assistant is required by [Red Hat Upgrade Tool](https://github.com/upgrades-migrations/redhat-upgrade-tool), which performs the in-place upgrade of the system.
 


### PR DESCRIPTION
- [Landscape](https://landscape.io) has been integrated more with this project, it will now report any static analysis code issues for every PR. This change comes with a different code health icon URL.
- Also, switch off warnings about missing documentation strings.

Resolves https://github.com/upgrades-migrations/preupgrade-assistant/issues/309