### PR TITLE
Support older versions of the OpenSCAP

### DIFF
--- a/packaging/preupgrade-assistant.spec
+++ b/packaging/preupgrade-assistant.spec
@@ -48,9 +48,9 @@ Requires:       sed findutils bash
 Requires:       rpm-python
 Requires:       redhat-release
 Requires:       yum-utils
-Requires:       openscap%{?_isa} >= 0:1.2.8-1
-Requires:       openscap-engine-sce%{?_isa} >= 0:1.2.8-1
-Requires:       openscap-utils%{?_isa} >= 0:1.2.8-1
+Requires:       openscap%{?_isa} >= 0:1.0.10
+Requires:       openscap-engine-sce%{?_isa} >= 0:1.0.10
+Requires:       openscap-utils%{?_isa} >= 0:1.0.10
 Requires:       pykickstart
 Requires:       python-six
 Conflicts:      %{name}-tools < 2.1.0-1


### PR DESCRIPTION
Old OpenSCAP doesn't support new complex report style that is used
by default by the Preupgrade Assistant tool. Enforce the simple
style of report (like with --old-report-style) when version of
installed OpenSCAP is lower then 1.2.7. In case of enforced fallback
to the simple style of report log message to inform the user.

Additionaly change requirements to openscap* >= 0:1.0.10