### PR TITLE
Use the path to the copied module set directory instead of dirname

### DIFF
--- a/preupg/application.py
+++ b/preupg/application.py
@@ -274,7 +274,8 @@ class Application(object):
     def run_scan_process(self):
         """Function scans the source system"""
         self.xml_mgr = xml_manager.XmlManager(self.conf.assessment_results_dir,
-                                              self.module_set_dirname)
+                                              self.module_set_copy_path
+                                              )
 
         self.report_parser.add_global_tags(self.conf.assessment_results_dir,
                                            self.rename_custom_module_set(


### PR DESCRIPTION
The "placeholer" was not replaced, because XmlManager expects path
to the copied module set (/root/preupgrade/RHEL6_7) instead
of dirname (RHEL6_7).