### PR TITLE
Add missing Requires: httpd

### DIFF
--- a/packaging/preupgrade-assistant.spec
+++ b/packaging/preupgrade-assistant.spec
@@ -74,6 +74,7 @@ Group:      System Environment/Libraries
 Requires:   %{name}
 Requires:   sqlite
 Requires:   mod_wsgi
+Requires:   httpd
 Requires:   %{name} = %{version}-%{release}
 
 %description ui


### PR DESCRIPTION
At least `%post ui` script and `%files ui` rely on Apache being installed
(or at least its user/group being present).

So far this has *mostly* worked because it already Requires mod_wsgi,
which does pull in httpd, but that's not necessarily true for all
mod_wsgi packages; for example version of mod_wsgi shipped with Satellite
does not require it.

At any rate, correct way is to always declare dependencies directly on
things that we use.