### PR TITLE
Fix running 3rd party modules

### DIFF
--- a/preupg/application.py
+++ b/preupg/application.py
@@ -92,7 +92,6 @@ class Application(object):
         self.xml_mgr = None
         self.scanning_progress = None
         self.report_parser = None
-        self.report_data = {}
         self.text_convertor = ""
         self.common = None
         self._devel_mode = 0
@@ -108,7 +107,6 @@ class Application(object):
         self._add_report_log_file()
         self._add_debug_log_file()
         self.tar_ball_name = None
-        self.third_party = ""
         self._set_old_report_style()
 
     def _add_report_log_file(self):
@@ -166,13 +164,6 @@ class Application(object):
             self.old_report_style = True
         else:
             self.old_report_style = False
-
-    def get_third_party_dir(self, assessment):
-        """
-        Function returns a 3rdparty dir for upgrade path
-        like /root/preupgrade/RHEL6_7/3rdparty
-        """
-        return os.path.join(assessment, settings.add_ons)
 
     def get_postupgrade_dir(self):
         """Function returns postupgrade dir"""
@@ -393,31 +384,6 @@ class Application(object):
         PostupgradeHelper.special_postupgrade_scripts(self.conf.assessment_results_dir)
         PostupgradeHelper.hash_postupgrade_file(self.conf.verbose, self.get_postupgrade_dir())
 
-    def set_third_party(self, third_party):
-        self.third_party = third_party
-
-    def run_third_party_modules(self, dir_name):
-        """
-        Functions executes a 3rd party contents
-
-        3rd party contents are stored in
-        /usr/share/preupgrade/RHEL6_7/3rdparty directory
-        """
-        for module_set, all_xccdf_xml_path in \
-                get_installed_module_sets(dir_name):
-            third_party_name = self.third_party = module_set
-            log_message("Execution {0} assessments:".format(module_set))
-            self.report_parser.reload_xml(all_xccdf_xml_path)
-            self.all_xccdf_xml_path = all_xccdf_xml_path
-            self.run_scan_process()
-            self.report_data[third_party_name] = \
-                self.scanning_progress.get_output_data()
-            self.prepare_xml_for_html()
-            self.generate_html_or_text()
-            self.update_xml_after_html_generated()
-            self.copy_postupgrade_files()
-        self.set_third_party("")
-
     def get_cmd_convertor(self):
         """Function returns cmd with text convertor string"""
         cmd = settings.text_converters[self.text_convertor].format(
@@ -563,20 +529,12 @@ class Application(object):
         self.generate_html_or_text()
         self.update_xml_after_html_generated()
         self.copy_postupgrade_files()
-
-        third_party_dir_name = self.get_third_party_dir(
-            self.module_set_copy_path)
-        if os.path.exists(third_party_dir_name):
-            self.run_third_party_modules(third_party_dir_name)
-
         self.copy_preupgrade_scripts(self.module_set_copy_path)
         ConfigFilesHelper.copy_modified_config_files(
             settings.assessment_results_dir)
 
         # It prints out result in table format
         ScanningHelper.format_rules_to_table(main_report, "main contents")
-        for target, report in iter(self.report_data.items()):
-            ScanningHelper.format_rules_to_table(report, "3rdparty content " + target)
 
         self.tar_ball_name = TarballHelper.tarball_result_dir(self.conf.tarball_name, self.conf.verbose)
         log_message("The tarball with results is stored in '%s' ." % self.tar_ball_name)
@@ -615,12 +573,6 @@ class Application(object):
             # together by default) or has chosen upgrade only = print warning
             # to backup the system before doing the in-place upgrade
             log_message(settings.upgrade_backup_warning)
-        if self.report_data:
-            log_message('Summary of the third party providers:')
-            for target, dummy_report in iter(self.report_data.items()):
-                self.third_party = target
-                log_message("Read the third party content {0} {1} for more details.".
-                            format(target, path))
         log_message("Upload results to UI by the command:\ne.g. {0} .".format(command))
         return report_return_value
 

--- a/preupg/settings.py
+++ b/preupg/settings.py
@@ -79,9 +79,6 @@ common_name = "common"
 # path to file with definitions of common scripts
 common_scripts = os.path.join(data_dir, "preassessment", "scripts.txt")
 
-# Addons dir for 3rdparty contents
-add_ons = "3rdparty"
-
 # Default module set descriptor file
 all_xccdf_xml_filename = "all-xccdf.xml"
 

--- a/preupg/utils.py
+++ b/preupg/utils.py
@@ -390,35 +390,6 @@ class SystemIdentification(object):
         except IndexError:
             return None
 
-    @staticmethod
-    def get_addon_variant():
-        """
-        Function returns a addons variant if available
-
-        83 - HighAvailability
-        85 - LoadBalancer
-        90 - ResilientStorage
-        92 - ScalableFileSystem
-        """
-        mapping_dict = {
-            '83.pem': 'HighAvailability',
-            '85.pem': 'LoadBalancer',
-            '90.pem': 'ResilientStorage',
-            '92.pem': 'ScalableFileSystem',
-        }
-        variant = ['optional']
-        pki_dir = "/etc/pki/product"
-        if os.path.isdir(pki_dir):
-            pem_files = [x for x in os.listdir(pki_dir) if x.endswith(".pem")]
-            for pem in pem_files:
-                # Curently we don't use the openssl command for getting certificate
-                # PEM numbers are not changed between versions.
-                #cmd = settings.openssl_command.format(os.path.join(pki_dir, pem))
-                #lines = run_subprocess(cmd, print_output=True, shell=True)
-                if pem in mapping_dict.keys():
-                    variant.append(mapping_dict[pem])
-        return variant
-
 
 class TarballHelper(object):
 
@@ -717,18 +688,16 @@ class PostupgradeHelper(object):
 
 class OpenSCAPHelper(object):
 
-    def __init__(self, result_dir, result_name, xml_result_name, html_result_name, content, third_party=None):
+    def __init__(self, result_dir, result_name, xml_result_name, html_result_name, content):
         self.binary = [settings.openscap_binary]
         self.result_dir = result_dir
-        self.third_party = third_party
         self.xml_result_name = xml_result_name
         self.html_result_name = html_result_name
         self.result_name = result_name
         self.content = content
 
-    def update_variables(self, result_dir, result_name, xml_result_name, html_result_name, content, third_party=None):
+    def update_variables(self, result_dir, result_name, xml_result_name, html_result_name, content):
         self.result_dir = result_dir
-        self.third_party = third_party
         self.xml_result_name = xml_result_name
         self.html_result_name = html_result_name
         self.result_name = result_name
@@ -810,22 +779,13 @@ class OpenSCAPHelper(object):
         command.append(FileHelper.check_xml(self.content))
         return command
 
-    @staticmethod
-    def get_third_party_name(third_party):
-        """Function returns correct third party name"""
-        if third_party != "" and not third_party.endswith("_"):
-            third_party += "_"
-        return third_party
-
     def get_default_xml_result_path(self):
         """Returns full XML result path"""
-        return os.path.join(self.result_dir,
-                            OpenSCAPHelper.get_third_party_name("") + self.xml_result_name)
+        return os.path.join(self.result_dir, self.xml_result_name)
 
     def get_default_html_result_path(self):
         """Returns full HTML result path"""
-        return os.path.join(self.result_dir,
-                            OpenSCAPHelper.get_third_party_name("") + self.html_result_name)
+        return os.path.join(self.result_dir, self.html_result_name)
 
     def get_default_txt_result_path(self):
         """
@@ -833,8 +793,7 @@ class OpenSCAPHelper(object):
 
         :return: default txt result path
         """
-        return os.path.join(self.result_dir,
-                            OpenSCAPHelper.get_third_party_name("") + self.result_name + ".txt")
+        return os.path.join(self.result_dir, self.result_name + ".txt")
 
     def run_generate(self, xml_file, html_file, old_style=False):
         """

--- a/preupg/xmlgen/compose.py
+++ b/preupg/xmlgen/compose.py
@@ -33,20 +33,29 @@ class XCCDFCompose(object):
     """
     Prepare result directory and take care of creating all-xccdf.xml file
     """
-    def __init__(self, argument):
+
+    def __init__(self, src_path, dst_path=None):
         """
-        Specify dirname with the on content
-        :param argument: dirname where content is
-        :return:
+        Create the XCCDFCompose object with specified src and dst path.
+
+        The src_path specify source modules from which the XCCDF compose should
+        be created on the dst_path. In case the dst_path is not specified, the
+        result directory will be created, in the same place the source directory
+        exists, with the "-results" suffix using the original dirname.
         """
-        self.result_dir = argument
-        self.dir_name = self.result_dir + settings.results_postfix
-        if self.result_dir.endswith("/"):
-            self.dir_name = self.result_dir[:-1] + settings.results_postfix
+        self.src_path = src_path
+        if not dst_path:
+            self.dst_path = self.src_path + settings.results_postfix
+            if self.src_path.endswith("/"):
+                self.dst_path = self.src_path[:-1] + settings.results_postfix
+        else:
+            self.dst_path = dst_path
 
         # Delete previous contents if they exist.
-        if os.path.exists(self.dir_name):
-            shutil.rmtree(self.dir_name)
+        # FIXME: raise exception or inhibit remove of self.dst_path when
+        #        self.dst_path == self.src_path
+        if os.path.exists(self.dst_path):
+            shutil.rmtree(self.dst_path)
 
     def generate_xml(self, generate_from_ini=True):
         """
@@ -60,18 +69,18 @@ class XCCDFCompose(object):
                        !0 error
         """
         try:
-            ModuleSetUtils.get_module_set_os_versions(self.result_dir)
+            ModuleSetUtils.get_module_set_os_versions(self.src_path)
         except EnvironmentError as err:
             sys.stderr.write("{0}\n".format(str(err)))
             return ReturnValues.SCENARIO
 
         # e.g. /root/preupgrade/RHEL6_7 -> /root/preupgrade/RHEL6_7-results
-        dir_util.copy_tree(self.result_dir, self.dir_name)
+        dir_util.copy_tree(self.src_path, self.dst_path)
         # create content for all-xccdf.xml file as ElementTree object
         target_tree = ComposeXML.run_compose(
-            self.dir_name, generate_from_ini=generate_from_ini)
+            self.dst_path, generate_from_ini=generate_from_ini)
         # path where all-xccdf.xml is going to be generated
-        report_filename = os.path.join(self.dir_name,
+        report_filename = os.path.join(self.dst_path,
                                        settings.all_xccdf_xml_filename)
         if generate_from_ini:
             try:
@@ -79,15 +88,14 @@ class XCCDFCompose(object):
                     report_filename, "wb",
                     ElementTree.tostring(target_tree, "utf-8"), False
                 )
-                print('Generated report file for Preupgrade Assistant is: %s'
-                      % report_filename)
+                logger_debug.debug('Generated: %s' % report_filename)
             except IOError:
                 raise IOError("Error: Problem with writing file %s"
                               % report_filename)
         return 0
 
     def get_compose_dir_name(self):
-        return self.dir_name
+        return self.dst_path
 
 
 class ComposeXML(object):

--- a/preupg/xmlgen/compose.py
+++ b/preupg/xmlgen/compose.py
@@ -42,6 +42,9 @@ class XCCDFCompose(object):
         be created on the dst_path. In case the dst_path is not specified, the
         result directory will be created, in the same place the source directory
         exists, with the "-results" suffix using the original dirname.
+
+        src_path and dst_path has to be different, otherwise ValueError
+        exception is raised.
         """
         self.src_path = src_path
         if not dst_path:
@@ -50,10 +53,10 @@ class XCCDFCompose(object):
                 self.dst_path = self.src_path[:-1] + settings.results_postfix
         else:
             self.dst_path = dst_path
+        if self.dst_path == self.src_path:
+            raise ValueError("src_path and dst_path has to be different.")
 
         # Delete previous contents if they exist.
-        # FIXME: raise exception or inhibit remove of self.dst_path when
-        #        self.dst_path == self.src_path
         if os.path.exists(self.dst_path):
             shutil.rmtree(self.dst_path)
 


### PR DESCRIPTION
Enable processing of third party modules. Original solution has been completely dropped (with additional dead code) because it was too messy and buggy. Current solution regenerates original XCCDF compose under `assessment_results_dir` from the used module-set. Limitation of this solution is processing of the third party modules in group with the others instead of previous idea to process them after the *main* set of modules is processed.

~~TODO~~ (Done):
  - handle situation when src and dst paths for XCCDFCompose are same. Currently the dst path is alwasy removed when exist  and this could lead into lost of original modules. This is not possible now, but it would in future. It will be better to handle it now to prevent such situation in future. Possible solution
    -  is to ignore given dst path and behave in the same way as dst path is not set
    - or raise an exception (preferred one) (**chosen one**)