### PR TITLE
Remove not needed pip test requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ The Preupgrade Assistant is a framework designed to run the Preupgrade Assistant
 
 ## Running unit tests
 
-- To install required python modules, enter:
-  `pip install test-requirements.txt`
 - Enter the `python setup.py test` command.
 
 ## Learning how to write modules

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,8 +1,0 @@
-# List of required packages for running unit tests
-# Pass this file to pip: pip install -r test-requirements.txt
-
-six
-https://github.com/bocekm/astroid/archive/py26_compatibility.zip
-https://github.com/bocekm/pylint/archive/py26_compatibility.zip
-importlib # required by pylint
-ordered_set


### PR DESCRIPTION
This PR has been triggered by an error in our CI environment in which installation of pylint (actually its dependency) failed and caused that our unit tests were not executed.

The removal of the pip packages installation is fine, see below:
 - we do not use pylint anymore (we use landscape.io instead)
- ordered_set is not needed on RHEL 6 (it may be needed with newer
versions of pykickstart but then it's a dependency of that package)
- six doesn't need to be installed through pip, there's a package for
that on RHEL 6

I haven't removed the `pylintrc` file as it should be picked up by Prospector - one of the tools called by Landscape.