### PR TITLE
Build XCCDF only from module.ini and group.ini files

### DIFF
--- a/preupg/settings.py
+++ b/preupg/settings.py
@@ -46,6 +46,7 @@ log_dir = "/var/log/preupgrade"
 # file with module set meta info
 properties_ini = "properties.ini"
 module_ini = "module.ini"
+group_ini = "group.ini"
 
 solution_txt = "solution.txt"
 check_script = "check"

--- a/preupg/xmlgen/oscap_group_xml.py
+++ b/preupg/xmlgen/oscap_group_xml.py
@@ -14,12 +14,12 @@ except ImportError:
     import ConfigParser as configparser
 
 from preupg.xmlgen.xml_utils import XmlUtils
-from preupg.utils import FileHelper, ModuleSetUtils
+from preupg.utils import FileHelper
 try:
     from xml.etree import ElementTree
 except ImportError:
     from elementtree import ElementTree
-from preupg import settings
+from preupg import settings, exception
 
 try:
     from xml.etree.ElementTree import ParseError
@@ -56,9 +56,19 @@ class OscapGroupXml(object):
         self.loded dict:
         self.loaded[ini_file_path] = {option1: value, option2: value, ...}
         """
-        for dir_name in os.listdir(self.dirname):
-            if dir_name.endswith(".ini"):
-                self.lists.append(os.path.join(self.dirname, dir_name))
+        found = 0
+        for file_name in os.listdir(self.dirname):
+            if file_name not in [settings.module_ini, settings.group_ini]:
+                continue
+            if found == 0:
+                self.lists.append(os.path.join(self.dirname, file_name))
+                found = 1
+            else:
+                raise exception.ModuleSetFormatError(
+                        "Cannot prepare XCCDF for OpenSCAP",
+                        "group.ini and module.ini are in the same directory %s"
+                        % self.dirname
+                        )
         for file_name in self.lists:
             if FileHelper.check_file(file_name, "r") is False:
                 continue

--- a/tests/test_creator.py
+++ b/tests/test_creator.py
@@ -85,10 +85,10 @@ class TestCreator(base.TestCase):
         self.puh.prepare_content_env()
         self.puh.create_final_content()
         group_ini = os.path.join(self.puh.get_upgrade_path(),
-                                 self.puh.get_group_name(), 'group.ini')
+                                 self.puh.get_group_name(), settings.group_ini)
         self.assertEqual(group_ini, os.path.join(self.upgrade_dir,
                                                  self.group_name,
-                                                 'group.ini'))
+                                                 settings.group_ini))
         lines = load_file(group_ini)
         expected_group_ini = ['[preupgrade]',
                               'group_title = Title for foobar_group',

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -121,7 +121,7 @@ class TestScriptGenerator(base.TestCase):
         if os.path.exists(self.dirname):
             shutil.rmtree(self.dirname)
         os.makedirs(self.dirname)
-        self.filename = os.path.join(self.dirname, 'test.ini')
+        self.filename = os.path.join(self.dirname, settings.module_ini)
         self.rule = []
         self.loaded_ini = {}
         self.test_ini = {'content_title': 'Testing content title',
@@ -218,7 +218,7 @@ class TestXML(base.TestCase):
         if os.path.exists(self.dirname):
             shutil.rmtree(self.dirname)
         os.makedirs(self.dirname)
-        self.filename = os.path.join(self.dirname, 'test.ini')
+        self.filename = os.path.join(self.dirname, settings.module_ini)
         self.rule = []
         self.loaded_ini = {}
         test_ini = {'content_title': 'Testing content title',
@@ -476,7 +476,7 @@ class TestIncorrectINI(base.TestCase):
         self.root_dir_name = "tests/FOOBAR6_7"
         self.dir_name = os.path.join(self.root_dir_name, "incorrect_ini")
         os.makedirs(self.dir_name)
-        self.filename = os.path.join(self.dir_name, 'test.ini')
+        self.filename = os.path.join(self.dir_name, settings.module_ini)
         self.rule = []
         self.test_ini = {'content_title': 'Testing content title',
                          'content_description': 'Some content description',
@@ -528,7 +528,7 @@ class TestGroupXML(base.TestCase):
         self.root_dir_name = "tests/FOOBAR6_7"
         self.dir_name = os.path.join(self.root_dir_name, "test_group")
         os.makedirs(self.dir_name)
-        self.filename = os.path.join(self.dir_name, 'group.ini')
+        self.filename = os.path.join(self.dir_name, settings.group_ini)
         test_ini = {'group_title': 'Testing content title'}
         self.assertTrue(test_ini)
         self.loaded_ini[self.filename] = test_ini


### PR DESCRIPTION
  
    Previously building of module set has been corrupted when directory
    with the module contained more than one file with the ".ini"
    extentions. Build of the module set shouldn't be affected by various
    INI files, that are not related to the module set structure.
    
    So the scan is now read only group.ini and module.ini files whose
    names are reserved for PA purposes. In addition we expect only one
    of those files in each directory, so the ModuleSetFormatError
    exception is raised when both are detected in the same directory.
   
    Additionaly: 
      - removed unused import of ModuleSetUtils
      - modified tests
    
    Resolves #310