### PR TITLE
Fix reading VALUE_EXECUTABLES file with non-UTF-8 chars

### DIFF
--- a/preupg/script_api.py
+++ b/preupg/script_api.py
@@ -513,7 +513,6 @@ def check_rpm_to(check_rpm="", check_bin=""):
 
     if check_bin != "":
         binaries = check_bin.split(',')
-        lines = FileHelper.get_file_content(VALUE_EXECUTABLES, "rb", True)
         for binary in binaries:
             cmd = "which %s" % binary
             if ProcessHelper.run_subprocess(cmd, print_output=False, shell=True) != 0:

--- a/preupg/utils.py
+++ b/preupg/utils.py
@@ -183,7 +183,7 @@ class FileHelper(object):
         if decode_flag:
             f = codecs.open(full_path, perms, settings.defenc)
         else:
-            f = codecs.open(full_path, perms)
+            f = open(full_path, perms)
         try:
             data = f.read() if not method else f.readlines()
         finally:


### PR DESCRIPTION
The Python API function `check_rpm_to` was calling `get_file_content()` (with UTF-8 decoding flag being True) that **had no purpose there** and it was causing tracebacks for users when the _executable.log_ (`VALUE_EXECUTABLES`) file contained some non-UTF-8 characters.

```
Traceback (most recent call last):
  File "/root/preupgrade/RHEL6_7/system/RemovableMedia/check", line 24, in &lt;module&gt;
    check_rpm_to (check_rpm="",check_bin="lsblk")
  File "/usr/lib/python2.6/site-packages/preupg/script_api.py", line 526, in check_rpm_to
    lines = FileHelper.get_file_content(VALUE_EXECUTABLES, "rb", True)
  File "/usr/lib/python2.6/site-packages/preupg/utils.py", line 186, in get_file_content
    data = f.read() if not method else f.readlines()
  File "/usr/lib64/python2.6/codecs.py", line 679, in readlines
    return self.reader.readlines(sizehint)
  File "/usr/lib64/python2.6/codecs.py", line 588, in readlines
    data = self.read()
  File "/usr/lib64/python2.6/codecs.py", line 477, in read
    newchars, decodedbytes = self.decode(data, self.errors)
UnicodeDecodeError: 'utf8' codec can't decode byte 0xa2 in position 132483621: invalid start byte
```

Related cleanup:
The method for opening a file without decoding `codecs.open()` is not needed, built-in `open()` is sufficient.