### PR TITLE
Get rid of python-six

### DIFF
--- a/packaging/preupgrade-assistant.spec
+++ b/packaging/preupgrade-assistant.spec
@@ -38,7 +38,6 @@ BuildRequires:  python-setuptools
 BuildRequires:  rpm-python
 BuildRequires:  diffstat
 %if 0%{?rhel}
-BuildRequires:  python-six
 BuildRequires:  pykickstart
 %endif # RHEL
 Requires(post):   /sbin/ldconfig
@@ -52,7 +51,6 @@ Requires:       openscap%{?_isa} >= 0:1.0.10
 Requires:       openscap-engine-sce%{?_isa} >= 0:1.0.10
 Requires:       openscap-utils%{?_isa} >= 0:1.0.10
 Requires:       pykickstart
-Requires:       python-six
 Conflicts:      %{name}-tools < 2.1.0-1
 Obsoletes:      %{name} < 2.1.3-1
 

--- a/preupg/utils.py
+++ b/preupg/utils.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function, unicode_literals
-import six
 import datetime
 import re
 import subprocess
@@ -213,7 +212,7 @@ class FileHelper(object):
                 f.writelines(data)
             else:
                 # TODO: May we should print warn w
-                if encode_flag is True and isinstance(data, six.text_type):
+                if encode_flag is True and isinstance(data, unicode):
                     f.write(data.encode(settings.defenc))
                 else:
                     f.write(data)
@@ -343,7 +342,7 @@ class ProcessHelper(object):
                               stderr=subprocess.STDOUT,
                               shell=shell,
                               bufsize=1)
-        stdout = six.binary_type() # FIXME should't be this bytes()?
+        stdout = str() # FIXME should't be this bytes()?
         for stdout_data in iter(sp.stdout.readline, b''):
             # communicate() method buffers everything in memory, we will read stdout directly
             stdout += stdout_data


### PR DESCRIPTION
Remove last use of the python-six library as we do not plan to support Python 3 and it breaks dependencies for RHEL 6.6.

Related: #322 