### PR TITLE
Support RHEL 6.6

### DIFF
--- a/etc/preupgrade-assistant.conf
+++ b/etc/preupgrade-assistant.conf
@@ -2,12 +2,3 @@
 home_directory_file=.preupgrade_dirs
 # Syntax is mentioned below in section [home-dirs]
 user_config_file=enabled
-
-[home-dirs]
-# User is responsible for valid input in this part.
-# All paths should be escaped if contains e.g. whitespaces
-# Otherwise directories/files can be skipped.
-# if you want to add directories items which start with "#" or looks likes
-# config section, supported format is ./#name or ./[something]
-.config/
-.mozilla/

--- a/packaging/preupgrade-assistant.spec
+++ b/packaging/preupgrade-assistant.spec
@@ -38,7 +38,6 @@ BuildRequires:  python-setuptools
 BuildRequires:  rpm-python
 BuildRequires:  diffstat
 %if 0%{?rhel}
-BuildRequires:  python-six
 BuildRequires:  pykickstart
 %endif # RHEL
 Requires(post):   /sbin/ldconfig
@@ -52,7 +51,6 @@ Requires:       openscap%{?_isa} >= 0:1.0.10
 Requires:       openscap-engine-sce%{?_isa} >= 0:1.0.10
 Requires:       openscap-utils%{?_isa} >= 0:1.0.10
 Requires:       pykickstart
-Requires:       python-six
 Conflicts:      %{name}-tools < 2.1.0-1
 Obsoletes:      %{name} < 2.1.3-1
 

--- a/packaging/preupgrade-assistant.spec
+++ b/packaging/preupgrade-assistant.spec
@@ -47,9 +47,9 @@ Requires:       sed findutils bash
 Requires:       rpm-python
 Requires:       redhat-release
 Requires:       yum-utils
-Requires:       openscap%{?_isa} >= 0:1.0.10
-Requires:       openscap-engine-sce%{?_isa} >= 0:1.0.10
-Requires:       openscap-utils%{?_isa} >= 0:1.0.10
+Requires:       openscap%{?_isa} >= 0:1.0.8
+Requires:       openscap-engine-sce%{?_isa} >= 0:1.0.8
+Requires:       openscap-utils%{?_isa} >= 0:1.0.8
 Requires:       pykickstart
 Conflicts:      %{name}-tools < 2.1.0-1
 Obsoletes:      %{name} < 2.1.3-1

--- a/preupg/script_api.py
+++ b/preupg/script_api.py
@@ -668,7 +668,7 @@ def load_pa_configuration():
                   % PREUPGRADE_CONFIG)
         exit_error()
 
-    config = configparser.RawConfigParser(allow_no_value=True)
+    config = configparser.RawConfigParser()
     config.read(PREUPGRADE_CONFIG)
     section = 'preupgrade-assistant'
     home_option = 'home_directory_file'
@@ -694,7 +694,7 @@ def print_home_dirs(user_name=""):
                   % PREUPGRADE_CONFIG)
         exit_error()
 
-    config = configparser.RawConfigParser(allow_no_value=True)
+    config = configparser.RawConfigParser()
     home_option = 'home-dirs'
     try:
         if USER_CONFIG_FILE == 'enabled' and user_name == "":

--- a/preupg/utils.py
+++ b/preupg/utils.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function, unicode_literals
-import six
 import datetime
 import re
 import subprocess
@@ -213,7 +212,7 @@ class FileHelper(object):
                 f.writelines(data)
             else:
                 # TODO: May we should print warn w
-                if encode_flag is True and isinstance(data, six.text_type):
+                if encode_flag is True and isinstance(data, unicode):
                     f.write(data.encode(settings.defenc))
                 else:
                     f.write(data)
@@ -343,7 +342,7 @@ class ProcessHelper(object):
                               stderr=subprocess.STDOUT,
                               shell=shell,
                               bufsize=1)
-        stdout = six.binary_type() # FIXME should't be this bytes()?
+        stdout = str() # FIXME should't be this bytes()?
         for stdout_data in iter(sp.stdout.readline, b''):
             # communicate() method buffers everything in memory, we will read stdout directly
             stdout += stdout_data

--- a/preupg/utils.py
+++ b/preupg/utils.py
@@ -467,7 +467,7 @@ class ConfigHelper(object):
         if not os.path.exists(full_path):
             return None
 
-        config = configparser.RawConfigParser(allow_no_value=True)
+        config = configparser.RawConfigParser()
         config.read(full_path)
         if config.has_section(section):
             if config.has_option(section, key):
@@ -477,7 +477,7 @@ class ConfigHelper(object):
     def config_has_section(config_path, section):
         if not os.path.exists(config_path):
             return False
-        config = configparser.RawConfigParser(allow_no_value=True)
+        config = configparser.RawConfigParser()
         config.read(config_path)
         return True if config.has_section(section) else False
 


### PR DESCRIPTION
This workd is based on #356, where instead of bundling `ConfigParser` it removes the legacy config options that required the use of `allow_no_value`.